### PR TITLE
Make tensor opaque

### DIFF
--- a/code/cubical/DFA/Decider.agda
+++ b/code/cubical/DFA/Decider.agda
@@ -33,22 +33,30 @@ module _ (D : DFA {ℓD}) where
   open Algebra
   open AlgebraHom
 
-  run-from-state : string ⊢ LinΠ[ q ∈ ⟨ Q ⟩ ] TraceFrom q
-  run-from-state = foldKL*r char the-alg
-    where
-    the-alg : *r-Algebra char
-    the-alg .the-ℓ = ℓD
-    the-alg .G = LinΠ[ q ∈ ⟨ Q ⟩ ] TraceFrom q
-    the-alg .nil-case = LinΠ-intro (λ q → LinΣ-intro q ∘g nil)
-    the-alg .cons-case = LinΠ-intro (λ q →
-      ⟜-intro⁻ (LinΣ-elim (λ c →
-        ⟜-intro {k = TraceFrom q}
-          (⊸-intro⁻
-            (LinΣ-elim
-              (λ q' → ⊸-intro {k = TraceFrom q}
-                (LinΣ-intro {h = λ q'' → Trace q'' q} q' ∘g
-                  Trace.cons q c))
-            ∘g LinΠ-app (δ q c))))))
+  opaque
+    unfolding _⊗_
+    run-from-state : string ⊢ LinΠ[ q ∈ ⟨ Q ⟩ ] TraceFrom q
+    run-from-state = foldKL*r char the-alg
+      where
+        the-cons :
+          char ⊗ LinΠ[ q ∈ ⟨ Q ⟩ ] TraceFrom q ⊢
+            LinΠ[ q ∈ ⟨ Q ⟩ ] TraceFrom q
+        the-cons =
+          LinΠ-intro (λ q →
+          ⟜-intro⁻ (LinΣ-elim (λ c →
+            ⟜-intro {k = TraceFrom q}
+              (⊸-intro⁻
+                (LinΣ-elim
+                  (λ q' → ⊸-intro {k = TraceFrom q}
+                    (LinΣ-intro {h = λ q'' → Trace q'' q} q' ∘g
+                      Trace.cons q c))
+                ∘g LinΠ-app (δ q c))))))
+
+        the-alg : *r-Algebra char
+        the-alg .the-ℓ = ℓD
+        the-alg .G = LinΠ[ q ∈ ⟨ Q ⟩ ] TraceFrom q
+        the-alg .nil-case = LinΠ-intro (λ q → LinΣ-intro q ∘g nil)
+        the-alg .cons-case = the-cons
 
   check-accept : {q-start : ⟨ Q ⟩} (q-end : ⟨ Q ⟩) →
     Trace q-end q-start ⊢

--- a/code/cubical/DFA/Examples.agda
+++ b/code/cubical/DFA/Examples.agda
@@ -40,7 +40,7 @@ module examples where
   open DFA
 
   opaque
-    unfolding _⊕_ ⊕-elim ⊕-inl ⊕-inr ⟜-intro ⊸-intro
+    unfolding _⊕_ ⊕-elim ⊕-inl ⊕-inr ⟜-intro ⊸-intro _⊗_ ⌈w⌉→string KL*r-elim run-from-state
     is-inl : ∀ w → (g : Grammar ℓg) (h : Grammar ℓh) → (g ⊕ h) w → Bool
     is-inl w g h p = Sum.rec (λ _ → true) (λ _ → false) p
 
@@ -74,33 +74,33 @@ module examples where
     _ : mktest w' D ≡ true
     _ = refl
 
-    _ : mktest w'' D ≡ false
-    _ = refl
+   --  _ : mktest w'' D ≡ false
+   --  _ = refl
 
-    _ : mktest [] D ≡ true
-    _ = refl
+   --  _ : mktest [] D ≡ true
+   --  _ = refl
 
 
-   {--       0
-   -- 0  --------> 1
-   --    <--------
-   --        0
-   -- and self loops for 1. state 1 is acc
-   --
-   --}
-    D' : DFA {ℓ-zero}
-    Q D' = (Fin 2) , isFinSetFin
-    init D' = inl _
-    isAcc D' x =
-      ((x ≡ fsuc fzero) , isSetFin x (fsuc fzero)) ,
-      discreteFin x (fsuc fzero)
-    δ D' fzero fzero = fromℕ 1
-    δ D' fzero (fsuc fzero) = fromℕ 0
-    δ D' (fsuc fzero) fzero = fromℕ 0
-    δ D' (fsuc fzero) (fsuc fzero) = fromℕ 1
+   -- {--       0
+   -- -- 0  --------> 1
+   -- --    <--------
+   -- --        0
+   -- -- and self loops for 1. state 1 is acc
+   -- --
+   -- --}
+   --  D' : DFA {ℓ-zero}
+   --  Q D' = (Fin 2) , isFinSetFin
+   --  init D' = inl _
+   --  isAcc D' x =
+   --    ((x ≡ fsuc fzero) , isSetFin x (fsuc fzero)) ,
+   --    discreteFin x (fsuc fzero)
+   --  δ D' fzero fzero = fromℕ 1
+   --  δ D' fzero (fsuc fzero) = fromℕ 0
+   --  δ D' (fsuc fzero) fzero = fromℕ 0
+   --  δ D' (fsuc fzero) (fsuc fzero) = fromℕ 1
 
-    s : String
-    s = fsuc fzero ∷ fzero ∷ []
+   --  s : String
+   --  s = fsuc fzero ∷ fzero ∷ []
 
-    _ : mktest s D' ≡ true
-    _ = refl
+   --  _ : mktest s D' ≡ true
+   --  _ = refl

--- a/code/cubical/Examples/BinOp.agda
+++ b/code/cubical/Examples/BinOp.agda
@@ -63,7 +63,7 @@ module LL⟨1⟩ where
   -- need to look ahead one token to know if you continue matching
   -- close parens or have finished parsing the Atom.
   opaque
-    unfolding _⊗_ 
+    unfolding _⊗_
     num' : ∀ {n} → ε ⊢ Atom ⟜ literal (num n)
     num' {n} = ⟜-intro-ε {k = Atom} (num {n})
     parens' : ε ⊢ Atom ⟜ literal RP ⟜ Exp ⟜ literal LP

--- a/code/cubical/Examples/BinOp.agda
+++ b/code/cubical/Examples/BinOp.agda
@@ -1,4 +1,5 @@
 {- Grammar for one associative binary operation with constants and parens -}
+{-# OPTIONS -WnoUnsupportedIndexedMatch #-}
 module Examples.BinOp where
 
 open import Cubical.Foundations.Prelude
@@ -12,317 +13,355 @@ open import Cubical.Data.Maybe as Maybe
 open import Cubical.Data.Nat as Nat
 open import Cubical.Data.FinSet
 open import Cubical.Data.Sum as Sum
+open import Cubical.Data.Sigma
 
 -- TODO need to make this work with opaqueness
--- data Tok : Type where
---   LP RP : Tok   -- parens
---   * : Tok       -- the binary operation
---   num : ℕ → Tok -- constants
+data Tok : Type where
+  LP RP : Tok   -- parens
+  * : Tok       -- the binary operation
+  num : ℕ → Tok -- constants
 
--- Alphabet : hSet _
--- Alphabet = Tok , isSetRetract encode decode dex≡x (isSet⊎ isSetFin isSetℕ)
---   where
---   open import Cubical.Data.Sum as Sum
---   open import Cubical.Data.Fin as Fin
---   Tok' = Fin 3 ⊎ ℕ
---   encode : Tok → Tok'
---   encode LP = inl 0
---   encode RP = inl 1
---   encode * = inl 2
---   encode (num x) = inr x
---   decode : Tok' → Tok
---   decode (inl (0 , snd₁)) = LP
---   decode (inl (1 , snd₁)) = RP
---   decode (inl (suc (suc fst₁) , snd₁)) = *
---   decode (inr x) = num x
---   dex≡x : ∀ x → decode (encode x) ≡ x
---   dex≡x LP = refl
---   dex≡x RP = refl
---   dex≡x * = refl
---   dex≡x (num x) = refl
+Alphabet : hSet _
+Alphabet = Tok , isSetRetract encode decode dex≡x (isSet⊎ isSetFin isSetℕ)
+  where
+  open import Cubical.Data.Sum as Sum
+  open import Cubical.Data.Fin as Fin
+  Tok' = Fin 3 ⊎ ℕ
+  encode : Tok → Tok'
+  encode LP = inl 0
+  encode RP = inl 1
+  encode * = inl 2
+  encode (num x) = inr x
+  decode : Tok' → Tok
+  decode (inl (0 , snd₁)) = LP
+  decode (inl (1 , snd₁)) = RP
+  decode (inl (suc (suc fst₁) , snd₁)) = *
+  decode (inr x) = num x
+  dex≡x : ∀ x → decode (encode x) ≡ x
+  dex≡x LP = refl
+  dex≡x RP = refl
+  dex≡x * = refl
+  dex≡x (num x) = refl
 
--- open import Grammar Alphabet
--- open import Grammar.Equivalence Alphabet
--- open import Term Alphabet
+open import Grammar Alphabet
+open import Grammar.Equivalence Alphabet
+open import Term Alphabet
 
--- anyNum : Grammar _
--- anyNum = LinΣ[ n ∈ ℕ ] literal (num n)
--- module LL⟨1⟩ where
---   Exp : Grammar ℓ-zero
---   data Atom : Grammar ℓ-zero
+anyNum : Grammar _
+anyNum = LinΣ[ n ∈ ℕ ] literal (num n)
+module LL⟨1⟩ where
+  Exp : Grammar ℓ-zero
+  data Atom : Grammar ℓ-zero
 
---   Exp = Atom ⊗ (KL* (literal * ⊗ Atom))
---   data Atom where
---     num : ∀ {n} → literal (num n) ⊢ Atom
---     parens : literal LP ⊗ Exp ⊗ literal RP ⊢ Atom
---   -- This grammar is LL(1) because after you match a close paren, you
---   -- need to look ahead one token to know if you continue matching
---   -- close parens or have finished parsing the Atom.
---   num' : ∀ {n} → ε ⊢ Atom ⟜ literal (num n)
---   num' {n} = ⟜-intro-ε {k = Atom} (num {n})
---   parens' = ⟜3-intro-ε parens
+  Exp = Atom ⊗' (KL* (literal * ⊗' Atom))
+  data Atom where
+    num : ∀ {n} → literal (num n) ⊢ Atom
+    parens :
+      literal LP ⊗' Exp ⊗' literal RP ⊢ Atom
 
---   record Algebra ℓ : Type (ℓ-suc ℓ) where
---     field
---       UE : Grammar ℓ
---       UAs : Grammar ℓ
---       UA : Grammar ℓ
+  -- This grammar is LL(1) because after you match a close paren, you
+  -- need to look ahead one token to know if you continue matching
+  -- close parens or have finished parsing the Atom.
+  opaque
+    unfolding _⊗_ 
+    num' : ∀ {n} → ε ⊢ Atom ⟜ literal (num n)
+    num' {n} = ⟜-intro-ε {k = Atom} (num {n})
+    parens' : ε ⊢ Atom ⟜ literal RP ⟜ Exp ⟜ literal LP
+    parens' = ⟜3-intro-ε parens
 
---       [mkExp] : UA ⊗ UAs ⊢ UE
---       [nil] : ε ⊢ UAs
---       [cons] : (literal * ⊗ UA) ⊗ UAs ⊢ UAs
---       [num] : ∀ {n} → literal (num n) ⊢ UA
---       [parens] : literal LP ⊗ UE ⊗ literal RP ⊢ UA
+  record Algebra ℓ : Type (ℓ-suc ℓ) where
+    field
+      UE : Grammar ℓ
+      UAs : Grammar ℓ
+      UA : Grammar ℓ
 
---   open Algebra
---   initialAlgebra : Algebra ℓ-zero
---   initialAlgebra .UE = Exp
---   initialAlgebra .UAs = KL* (literal * ⊗ Atom)
---   initialAlgebra .UA = Atom
---   initialAlgebra .[mkExp] = id
---   initialAlgebra .[nil] = nil
---   initialAlgebra .[cons] = cons
---   initialAlgebra .[num] = num
---   initialAlgebra .[parens] = parens
---   record Hom {ℓ}{ℓ'} (A : Algebra ℓ) (B : Algebra ℓ') : Type (ℓ-max ℓ ℓ') where
---     field
---       fE : A .UE ⊢ B .UE
---       fAs : A .UAs ⊢ B .UAs
---       fA : A .UA ⊢ B .UA
+      [mkExp] : UA ⊗ UAs ⊢ UE
+      [nil] : ε ⊢ UAs
+      [cons] : (literal * ⊗ UA) ⊗ UAs ⊢ UAs
+      [num] : ∀ {n} → literal (num n) ⊢ UA
+      [parens] : literal LP ⊗ UE ⊗ literal RP ⊢ UA
 
---   -- this can be avoided by doing manual recursion for rAs
---   fold : ∀ {ℓ}(A : Algebra ℓ) → Hom initialAlgebra A
---   fold A = record { fE = rE ; fAs = rAs ; fA = rA } where
---     rE : Exp ⊢ A .UE
---     rAs : KL* (literal * ⊗ Atom) ⊢ A .UAs
---     rA : Atom ⊢ A .UA
---     rE _ (sp , a , as) = A .[mkExp] _ (sp , rA _ a , rAs _ as)
---     rAs _ (KL*.nil _ x) = A .[nil] _ x
---     rAs _ (KL*.cons _ (sp1 , (sp2 , star , a) , as)) = A .[cons] _ (sp1 , (sp2 , star , rA _ a) , rAs _ as)
---     rA _ (num _ x) = A .[num] _ x
---     rA _ (parens _ (sp1 , lp , sp2 , e , rp)) = A .[parens] _ (sp1 , lp , sp2 , rE _ e , rp)
+  open Algebra
+  opaque
+    unfolding _⊗_
+    initialAlgebra : Algebra ℓ-zero
+    initialAlgebra .UE = Exp
+    initialAlgebra .UAs = KL* (literal * ⊗ Atom)
+    initialAlgebra .UA = Atom
+    initialAlgebra .[mkExp] = id
+    initialAlgebra .[nil] = nil
+    initialAlgebra .[cons] = cons
+    initialAlgebra .[num] = num
+    initialAlgebra .[parens] = parens
+  record Hom {ℓ}{ℓ'} (A : Algebra ℓ) (B : Algebra ℓ') : Type (ℓ-max ℓ ℓ') where
+    field
+      fE : A .UE ⊢ B .UE
+      fAs : A .UAs ⊢ B .UAs
+      fA : A .UA ⊢ B .UA
 
--- module Automaton where
---   -- TODO: we should be able to generalize this definition to an
---   -- (infinite state) deterministic automaton with guarded
---   -- transitions.
+  -- this can be avoided by doing manual recursion for rAs
+  opaque
+    unfolding _⊗_ initialAlgebra
+    fold : ∀ {ℓ}(A : Algebra ℓ) → Hom initialAlgebra A
+    fold A = record { fE = rE ; fAs = rAs ; fA = rA } where
+      rE : Exp ⊢ A .UE
+      rAs : KL* (literal * ⊗ Atom) ⊢ A .UAs
+      rA : Atom ⊢ A .UA
+      rE _ (sp , a , as) = A .[mkExp] _ (sp , rA _ a , rAs _ as)
+      rAs _ (KL*.nil _ x) = A .[nil] _ x
+      rAs _ (KL*.cons _ (sp1 , (sp2 , star , a) , as)) = A .[cons] _ (sp1 , (sp2 , star , rA _ a) , rAs _ as)
+      rA _ (num _ x) = A .[num] _ x
+      rA _ (parens _ (sp1 , lp , sp2 , e , rp)) = A .[parens] _ (sp1 , lp , sp2 , rE _ e , rp)
 
---   -- the stack is a number,
---   -- the number of open parens that are closed by the term
+module Automaton where
+  -- TODO: we should be able to generalize this definition to an
+  -- (infinite state) deterministic automaton with guarded
+  -- transitions.
 
---   -- Exp is for when we are parsing a single expression, Suffix is
---   -- when we are parsing the sequence of multiplications after an
---   -- expression
+  -- the stack is a number,
+  -- the number of open parens that are closed by the term
 
---   -- the boolean is whether it is an accepting or rejecting trace
+  -- Exp is for when we are parsing a single expression, Suffix is
+  -- when we are parsing the sequence of multiplications after an
+  -- expression
 
---   -- three cases: Opening, Closing, Multiplying
+  -- the boolean is whether it is an accepting or rejecting trace
 
---   -- Opening: at the start of an expression, the term starts with a
---   -- sequence of 0 or more opening parens, which we count. Ends when
---   -- we see a number, then we use lookahead to determine whether to
---   -- parse closing parens or start parsing a multiplication sequence
---   data Opening : ∀ (n : ℕ) (b : Bool) → Grammar ℓ-zero
---   -- Closing: parse as many closing parens as you can, eventually
---   -- use lookahead to decide when to start parsing multiplication sequence
---   data Closing : ∀ (n : ℕ) (b : Bool) → Grammar ℓ-zero
---   -- Parse a sequence of * Exps
---   data Multiplying : ∀ (n : ℕ) (b : Bool) → Grammar ℓ-zero
---   DoneOpening : ∀ (n : ℕ) (b : Bool) → Grammar ℓ-zero
---   DoneOpening n b =
---     ((ε ⊕ (literal * ⊕ literal LP ⊕ anyNum) ⊗ ⊤) & Multiplying n b)
---     ⊕ ((literal RP ⊗ ⊤) & Closing n b)
---   data Opening where
---     left : ∀ {n b} → literal LP ⊗ Opening (suc n) b ⊢ Opening n b
---     num  : ∀ {n b} →
---       (LinΣ[ m ∈ ℕ ] literal (num m)) ⊗ DoneOpening n b ⊢ Opening n b
---     unexpected : ∀ {n} → ε ⊕ (literal RP ⊕ literal *) ⊗ ⊤ ⊢ Opening n false
+  -- three cases: Opening, Closing, Multiplying
 
---   data Closing where
---     rightClose : ∀ {n b} →
---       literal RP ⊗ DoneOpening n b ⊢ Closing (suc n) b
---     rightUnmatched : literal RP ⊗ ⊤ ⊢ Closing 0 false
---     unexpected : ∀ {n} → ε ⊕ (literal * ⊕ literal LP ⊕ anyNum) ⊗ ⊤ ⊢ Closing n false
+  -- Opening: at the start of an expression, the term starts with a
+  -- sequence of 0 or more opening parens, which we count. Ends when
+  -- we see a number, then we use lookahead to determine whether to
+  -- parse closing parens or start parsing a multiplication sequence
+  data Opening : ∀ (n : ℕ) (b : Bool) → Grammar ℓ-zero
+  -- Closing: parse as many closing parens as you can, eventually
+  -- use lookahead to decide when to start parsing multiplication sequence
+  data Closing : ∀ (n : ℕ) (b : Bool) → Grammar ℓ-zero
+  -- Parse a sequence of * Exps
+  data Multiplying : ∀ (n : ℕ) (b : Bool) → Grammar ℓ-zero
+  DoneOpening : ∀ (n : ℕ) (b : Bool) → Grammar ℓ-zero
+  DoneOpening n b =
+    ((ε ⊕' (literal * ⊕' literal LP ⊕' anyNum) ⊗' ⊤) &' Multiplying n b)
+    ⊕' ((literal RP ⊗' ⊤) &' Closing n b)
+  data Opening where
+    left : ∀ {n b} → literal LP ⊗' Opening (suc n) b ⊢ Opening n b
+    num  : ∀ {n b} →
+      (LinΣ[ m ∈ ℕ ] literal (num m)) ⊗' DoneOpening n b ⊢ Opening n b
+    unexpected : ∀ {n} → ε ⊕' (literal RP ⊕' literal *) ⊗' ⊤ ⊢ Opening n false
 
---   data Multiplying where
---     done : ε ⊢ Multiplying 0 true
---     times : ∀ {n b} → literal * ⊗ Opening n b ⊢ Multiplying n b
---     unmatched : ∀ {n} → ε ⊢ Multiplying (suc n) false
---     unexpected : ∀ {n} →
---       (literal LP ⊕ literal RP ⊕ anyNum) ⊗ ⊤ ⊢ Multiplying n false
+  data Closing where
+    rightClose : ∀ {n b} →
+      literal RP ⊗' DoneOpening n b ⊢ Closing (suc n) b
+    rightUnmatched : literal RP ⊗' ⊤ ⊢ Closing 0 false
+    unexpected : ∀ {n} → ε ⊕' (literal * ⊕' literal LP ⊕' anyNum) ⊗' ⊤ ⊢ Closing n false
 
---   -- note this is for the true cases, the tautological one would also
---   -- have false cases but we would just use ⊥ for them.
---   --
---   -- because of this we are getting a `warning: -W[no]UnsupportedIndexedMatch`
---   record Algebra ℓ : Type (ℓ-suc ℓ) where
---     field
---       UO : ℕ → Grammar ℓ
---       UC : ℕ → Grammar ℓ
---       UM : ℕ → Grammar ℓ
---     UDO : ℕ → Grammar ℓ
---     UDO n = ((ε ⊕ (literal * ⊕ literal LP ⊕ anyNum) ⊗ ⊤) & UM n)
---       ⊕ ((literal RP ⊗ ⊤) & UC n)
---     field
---       [left] : ∀ {n} → literal LP ⊗ UO (suc n) ⊢ UO n
---       [num]  : ∀ {n} → (LinΣ[ m ∈ ℕ ] literal (num m)) ⊗ UDO n ⊢ UO n
---       [rightClose] : ∀ {n} → literal RP ⊗ UDO n ⊢ UC (suc n)
---       [done] : ε ⊢ UM 0
---       [times] : ∀ {n} → literal * ⊗ UO n ⊢ UM n
---   open Algebra
---   initialAlgebra : Algebra ℓ-zero
---   initialAlgebra .UO n = Opening n true
---   initialAlgebra .UC n = Closing n true
---   initialAlgebra .UM n = Multiplying n true
---   initialAlgebra .[left] = left
---   initialAlgebra .[num] = num
---   initialAlgebra .[rightClose] = rightClose
---   initialAlgebra .[times] = times
---   initialAlgebra .[done] = done
+  data Multiplying where
+    done : ε ⊢ Multiplying 0 true
+    times : ∀ {n b} → literal * ⊗' Opening n b ⊢ Multiplying n b
+    unmatched : ∀ {n} → ε ⊢ Multiplying (suc n) false
+    unexpected : ∀ {n} →
+      (literal LP ⊕' literal RP ⊕' anyNum) ⊗' ⊤ ⊢ Multiplying n false
 
---   record Hom {ℓ}{ℓ'} (A : Algebra ℓ) (B : Algebra ℓ') : Type (ℓ-max ℓ ℓ') where
---     field
---       fO : ∀ n → A .UO n ⊢ B .UO n
---       fC : ∀ n → A .UC n ⊢ B .UC n
---       fM : ∀ n → A .UM n ⊢ B .UM n
---       -- TODO: the equations
+  -- note this is for the true cases, the tautological one would also
+  -- have false cases but we would just use ⊥ for them.
+  --
+  -- because of this we are getting a `warning: -W[no]UnsupportedIndexedMatch`
+  record Algebra ℓ : Type (ℓ-suc ℓ) where
+    field
+      UO : ℕ → Grammar ℓ
+      UC : ℕ → Grammar ℓ
+      UM : ℕ → Grammar ℓ
+    UDO : ℕ → Grammar ℓ
+    UDO n = ((ε ⊕ (literal * ⊕ literal LP ⊕ anyNum) ⊗ ⊤) & UM n)
+      ⊕ ((literal RP ⊗ ⊤) & UC n)
+    field
+      [left] : ∀ {n} → literal LP ⊗ UO (suc n) ⊢ UO n
+      [num]  : ∀ {n} → (LinΣ[ m ∈ ℕ ] literal (num m)) ⊗ UDO n ⊢ UO n
+      [rightClose] : ∀ {n} → literal RP ⊗ UDO n ⊢ UC (suc n)
+      [done] : ε ⊢ UM 0
+      [times] : ∀ {n} → literal * ⊗ UO n ⊢ UM n
 
---   opaque
---     unfolding _⊕_  _&_
---     fold : ∀ {ℓ} (A : Algebra ℓ) → Hom initialAlgebra A
---     fold A = record { fO = rO ; fC = rC ; fM = rM } where
---       rO : ∀ n → Opening n true ⊢ A .UO n
---       rC : ∀ n → Closing n true ⊢ A .UC n
---       rM : ∀ n → Multiplying n true ⊢ A .UM n
---       rDO : ∀ n → DoneOpening n true ⊢ UDO A n
---       rO n w (left _ (sp , lp , o)) = A .[left] w (sp , (lp , rO _ _ o))
---       rO n w (num _ (sp , m , doo)) = A .[num] _ (sp , m , rDO _ _ doo)
---       rC _ w (rightClose _ (sp , rp , doo)) = A .[rightClose] _ (sp , rp , rDO _ _ doo)
---       rM _ w (done _ x) = A .[done] _ x
---       rM _ w (times _ (sp , star , o)) = A .[times] _ (sp , star , rO _ _ o)
---       rDO n w (inl x) = inl ((x .fst) , (rM _ _ (x .snd)))
---       rDO n w (inr x) = inr (x .fst , rC _ _ (x .snd))
---     Peek : Maybe Tok → Grammar ℓ-zero
---     Peek = Maybe.rec ε (λ c → literal c ⊗ ⊤)
+  open Algebra
+  opaque
+    unfolding _⊗_ _⊕_ _&_
+    initialAlgebra : Algebra ℓ-zero
+    initialAlgebra .UO n = Opening n true
+    initialAlgebra .UC n = Closing n true
+    initialAlgebra .UM n = Multiplying n true
+    initialAlgebra .[left] = left
+    initialAlgebra .[num] = num
+    initialAlgebra .[rightClose] = rightClose
+    initialAlgebra .[times] = times
+    initialAlgebra .[done] = done
 
---     Goal : Grammar ℓ-zero
---     Goal = LinearΣ Peek & LinΠ[ n ∈ ℕ ]
---       (LinearΣ (Opening n)
---       & LinearΣ (Closing n)
---       & LinearΣ (Multiplying n))
+  record Hom {ℓ}{ℓ'} (A : Algebra ℓ) (B : Algebra ℓ') : Type (ℓ-max ℓ ℓ') where
+    field
+      fO : ∀ n → A .UO n ⊢ B .UO n
+      fC : ∀ n → A .UC n ⊢ B .UC n
+      fM : ∀ n → A .UM n ⊢ B .UM n
+      -- TODO: the equations
 
---     parse' : string ⊢ LinearΣ Peek & LinΠ[ n ∈ ℕ ]
---       (LinearΣ (Opening n)
---       & LinearΣ (Closing n)
---       & LinearΣ (Multiplying n))
---     parse' = foldKL*r _ (record { the-ℓ = _ ; G = _
---       ; nil-case =
---         LinΣ-intro Maybe.nothing
---         ,& LinΠ-intro λ n →
---         (LinΣ-intro false ∘g unexpected ∘g ⊕-inl)
---         ,& (LinΣ-intro false ∘g unexpected ∘g ⊕-inl)
---         ,& Nat.elim {A = λ n → Term ε (LinearΣ (Multiplying n))} (LinΣ-intro true ∘g done) (λ n-1 _ → LinΣ-intro false ∘g unmatched) n
---       ; cons-case =
---         (⟜-intro⁻ (LinΣ-elim (λ tok → ⟜-intro {k = LinearΣ Peek} (LinΣ-intro {A = Maybe Tok} (just tok) ∘g id ,⊗ ⊤-intro))))
---         ,& LinΠ-intro λ n →
---           (⟜-intro⁻
---             (LinΣ-elim λ
---             { (num x) → ⟜-intro {k = LinearΣ (Opening n)} (⊸-intro⁻ (⇒-intro⁻ (LinΣ-elim λ
---               -- goto closing
---               { (just RP) → ⇒-intro (⇐-intro⁻ (((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Opening n)} (LinΣ-intro b ∘g num ∘g LinΣ-intro x ,⊗ ⊕-inr))) ∘g &-π₁) ∘g &-π₂))
---               ; nothing → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Opening n)} (LinΣ-intro b ∘g num ∘g LinΣ-intro x ,⊗ (⊕-inl ∘g ⊕-inl ,&p id)))) ∘g &-π₂ ∘g &-π₂))
---               ; (just *) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Opening n)} (LinΣ-intro b ∘g num ∘g LinΣ-intro x ,⊗ (⊕-inl ∘g (⊕-inr ∘g ⊕-inl ,⊗ id) ,&p id)))) ∘g &-π₂ ∘g &-π₂))
---               ; (just LP) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Opening n)} (LinΣ-intro b ∘g num ∘g LinΣ-intro x ,⊗ (⊕-inl ∘g (⊕-inr ∘g (⊕-inr ∘g ⊕-inl) ,⊗ id) ,&p id)))) ∘g &-π₂ ∘g &-π₂))
---               ; (just (num y)) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Opening n)} (LinΣ-intro b ∘g num ∘g LinΣ-intro x ,⊗ (⊕-inl ∘g (⊕-inr ∘g (⊕-inr ∘g ⊕-inr ∘g LinΣ-intro y) ,⊗ id) ,&p id)))) ∘g &-π₂ ∘g &-π₂))
---               }))
---               ∘g id ,⊗ id ,&p LinΠ-app n)
---               --  (⊸-intro⁻ (⇒-intro⁻ (LinΣ-elim λ
---             ; LP → ⟜-intro {k = LinearΣ (Opening n)} (⊸-intro⁻ (((LinΣ-elim (λ b → ⊸-intro {k = LinearΣ (Opening n)} (LinΣ-intro b ∘g left)) ∘g &-π₁)) ∘g LinΠ-app (suc n) ∘g &-π₂))
---             ; RP → ⟜-intro {k = LinearΣ (Opening n)} (LinΣ-intro false ∘g unexpected ∘g ⊕-inr ∘g ⊕-inl ,⊗ ⊤-intro)
---             ; * → ⟜-intro {k = LinearΣ (Opening n)} (LinΣ-intro false ∘g unexpected ∘g ⊕-inr ∘g ⊕-inr ,⊗ ⊤-intro)
---             })
---           )
---           -- ⟜-intro⁻
---           ,& ⟜-intro⁻ (LinΣ-elim λ
---            { RP → ⟜-intro {k = LinearΣ (Closing n)} (Nat.elim {A = λ n → Term (literal RP ⊗ Goal) (LinearΣ (Closing n))}
---              -- empty stack
---              (LinΣ-intro false ∘g rightUnmatched ∘g id ,⊗ ⊤-intro)
---              -- popped
---              (λ n-1 _ → (⊸-intro⁻ (⇒-intro⁻ (LinΣ-elim λ
---                { (just RP) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Closing _)} (LinΣ-intro b ∘g rightClose ∘g id ,⊗ ⊕-inr))) ∘g &-π₁ ∘g &-π₂))
---                ; nothing → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Closing _)} (LinΣ-intro b ∘g rightClose ∘g id ,⊗ (⊕-inl ∘g ⊕-inl ,&p id)))) ∘g &-π₂ ∘g &-π₂))
---                ; (just *) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Closing _)} (LinΣ-intro b ∘g rightClose ∘g id ,⊗ (⊕-inl ∘g (⊕-inr ∘g ⊕-inl ,⊗ id) ,&p id)))) ∘g &-π₂ ∘g &-π₂))
---                ; (just LP) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Closing _)} (LinΣ-intro b ∘g rightClose ∘g id ,⊗ (⊕-inl ∘g (⊕-inr ∘g (⊕-inr ∘g ⊕-inl) ,⊗ id) ,&p id)))) ∘g &-π₂ ∘g &-π₂))
---                ; (just (num x)) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Closing _)} (LinΣ-intro b ∘g rightClose ∘g id ,⊗ (⊕-inl ∘g (⊕-inr ∘g (⊕-inr ∘g ⊕-inr ∘g LinΣ-intro x) ,⊗ id) ,&p id)))) ∘g &-π₂ ∘g &-π₂))
---                })) ∘g id ,⊗ id ,&p LinΠ-app n-1))
---              n)
---            ; LP → ⟜-intro {k = LinearΣ (Closing n)} (LinΣ-intro false ∘g
---              unexpected ∘g ⊕-inr ∘g (⊕-inr ∘g ⊕-inl) ,⊗ ⊤-intro)
---            ; * → ⟜-intro {k = LinearΣ (Closing n)} (LinΣ-intro false ∘g
---              unexpected ∘g ⊕-inr ∘g ⊕-inl ,⊗ ⊤-intro)
---            ; (num x) → ⟜-intro {k = LinearΣ (Closing n)} (LinΣ-intro false ∘g
---              unexpected ∘g ⊕-inr ∘g (⊕-inr ∘g ⊕-inr ∘g LinΣ-intro x) ,⊗ ⊤-intro)
---            })
---           ,&
---          (⟜-intro⁻ (LinΣ-elim λ
---            { * → ⟜-intro {k = LinearΣ (Multiplying n)} (⊸-intro⁻ ((((LinΣ-elim λ b → ⊸-intro {k = LinearΣ (Multiplying n)} (LinΣ-intro b ∘g times)) ∘g &-π₁) ∘g LinΠ-app n) ∘g &-π₂))
---            ; LP → ⟜-intro {k = LinearΣ (Multiplying n)} (LinΣ-intro false ∘g unexpected ∘g ⊕-inl ,⊗ ⊤-intro)
---            ; RP → ⟜-intro {k = LinearΣ (Multiplying n)} (LinΣ-intro false ∘g unexpected ∘g (⊕-inr ∘g ⊕-inl) ,⊗ ⊤-intro)
---            ; (num x) → ⟜-intro {k = LinearΣ (Multiplying n)} (LinΣ-intro false ∘g unexpected ∘g (⊕-inr ∘g ⊕-inr ∘g LinΣ-intro x) ,⊗ ⊤-intro) }))
---       })
+  opaque
+    unfolding _⊗_ _⊕_ _&_ initialAlgebra
+    -- TODO these defs need indexed pattern matching
+    fold : ∀ {ℓ} (A : Algebra ℓ) → Hom initialAlgebra A
+    fold A = record { fO = rO ; fC = rC ; fM = rM } where
+      rO : ∀ n → Opening n true ⊢ A .UO n
+      rC : ∀ n → Closing n true ⊢ A .UC n
+      rM : ∀ n → Multiplying n true ⊢ A .UM n
+      rDO : ∀ n → DoneOpening n true ⊢ UDO A n
+      rO n w (left _ (sp , lp , o)) = A .[left] w (sp , (lp , rO _ _ o))
+      rO n w (num _ (sp , m , doo)) = A .[num] _ (sp , m , rDO _ _ doo)
+      rC _ w (rightClose _ (sp , rp , doo)) = A .[rightClose] _ (sp , rp , rDO _ _ doo)
+      rM _ w (done _ x) = A .[done] _ x
+      rM _ w (times _ (sp , star , o)) = A .[times] _ (sp , star , rO _ _ o)
+      rDO n w (inl x) = inl ((x .fst) , (rM _ _ (x .snd)))
+      rDO n w (inr x) = inr (x .fst , rC _ _ (x .snd))
+    Peek : Maybe Tok → Grammar ℓ-zero
+    Peek = Maybe.rec ε (λ c → literal c ⊗ ⊤)
 
---     parse : string ⊢ LinΣ[ b ∈ Bool ] Opening zero b
---     parse = ((&-π₁ ∘g LinΠ-app zero) ∘g &-π₂) ∘g parse'
+    Goal : Grammar ℓ-zero
+    Goal = LinearΣ Peek & LinΠ[ n ∈ ℕ ]
+      (LinearΣ (Opening n)
+      & LinearΣ (Closing n)
+      & LinearΣ (Multiplying n))
 
--- -- Soundness: i.e., that from every trace we can extract an LL(1) parse
--- module Soundness where
---   buildExp : Automaton.Opening 0 true ⊢ LL⟨1⟩.Exp
---   buildExp = ⊗-unit-r ∘g Automaton.Hom.fO (Automaton.fold alg) 0 where
---     open LL⟨1⟩ using (Exp; Atom)
---     open Automaton.Algebra
---     Stk : ℕ → Grammar ℓ-zero
---     Stk = Nat.elim ε
---       (λ _ Stk⟨n⟩ → literal RP ⊗ KL* (literal * ⊗ Atom) ⊗ Stk⟨n⟩)
---     alg : Automaton.Algebra ℓ-zero
---     alg .UO n = Exp ⊗ Stk n
---     alg .UC n = Stk n
---     alg .UM n = KL* (literal * ⊗ Atom) ⊗ Stk n
---     alg .[left] = ⊗-assoc ∘g ⟜3⊗ LL⟨1⟩.parens'
---     alg .[num] {n} = ⊸-intro⁻ (⊕-elim
---       -- the next thing was multiplying
---       (⊸-intro {k = Exp ⊗ Stk n} (⊗-assoc ∘g (LinΣ-elim λ _ → Atom.num) ,⊗ &-π₂))
---       -- the next thing was closing
---       (⊸-intro {k = Exp ⊗ Stk n} ((LinΣ-elim λ _ → Atom.num ,⊗ nil ∘g ⊗-unit-r⁻) ,⊗ &-π₂)))
---     alg .[rightClose] {n} = ⊸-intro⁻ (⊕-elim
---       -- next is multiplying
---       (⊸-intro {k = Stk (suc n)} (id ,⊗ &-π₂))
---       -- next is more closing
---       (⊸-intro {k = Stk (suc n)} (id ,⊗ (⟜0⊗ nil ∘g &-π₂))))
---     alg .[times] = ⟜2⊗ cons' ∘g ⊗-assoc ∘g id ,⊗ ⊗-assoc⁻
---     alg .[done] = ⟜0⊗ nil
+    -- TODO typechecking this parse term is very slow
+    -- Should probably split it into several pieces
+--     opaque
+--       -- unfolding LL⟨1⟩.fold LL⟨1⟩.num' LL⟨1⟩.parens' LL⟨1⟩.initialAlgebra _⊗_ _⊕_ _&_ _⇒_ ⊕-elim ⇒-intro ⇐-intro ⊸-intro ⊸-app ⟜-intro ⟜-app KL*r-elim fold initialAlgebra ⊗-intro &-intro &-π₁ &-π₂ ⊕-inl ⊕-inr ⇒-app
+--       parse' : string ⊢ LinearΣ Peek & LinΠ[ n ∈ ℕ ]
+--         (LinearΣ (Opening n)
+--         & LinearΣ (Closing n)
+--         & LinearΣ (Multiplying n))
+--       parse' = foldKL*r char
+--         (record {
+--           the-ℓ = ℓ-zero
+--         ; G = LinearΣ Peek & LinΠ[ n ∈ ℕ ]
+--               (LinearΣ (Opening n)
+--               & LinearΣ (Closing n)
+--               & LinearΣ (Multiplying n))
+--         ; nil-case =
+--           LinΣ-intro Maybe.nothing
+--           ,& LinΠ-intro λ n →
+--             (LinΣ-intro false ∘g unexpected ∘g ⊕-inl)
+--             ,& (LinΣ-intro false ∘g unexpected ∘g ⊕-inl)
+--             ,& Nat.elim {A = λ n → Term ε (LinearΣ (Multiplying n))} (LinΣ-intro true ∘g done) (λ n-1 _ → LinΣ-intro false ∘g unmatched) n
+--         ; cons-case =
+--           (⟜-intro⁻ (LinΣ-elim (λ tok → ⟜-intro {k = LinearΣ Peek}
+--             (LinΣ-intro {A = Maybe Tok} (just tok) ∘g id ,⊗ ⊤-intro))))
+--           ,& LinΠ-intro λ n →
+--             {!!}
+--         })
+--       -- foldKL*r _ (record { the-ℓ = _ ; G = _
+--       --   ; nil-case =
+--       --     LinΣ-intro Maybe.nothing
+--       --     ,& LinΠ-intro λ n →
+--       --     (LinΣ-intro false ∘g unexpected ∘g ⊕-inl)
+--       --     ,& (LinΣ-intro false ∘g unexpected ∘g ⊕-inl)
+--       --     ,& Nat.elim {A = λ n → Term ε (LinearΣ (Multiplying n))} (LinΣ-intro true ∘g done) (λ n-1 _ → LinΣ-intro false ∘g unmatched) n
+--       --   ; cons-case =
+--       --     (⟜-intro⁻ (LinΣ-elim (λ tok → ⟜-intro {k = LinearΣ Peek}
+--       --       (LinΣ-intro {A = Maybe Tok} (just tok) ∘g id ,⊗ ⊤-intro))))
+--       --     ,& LinΠ-intro λ n →
+--       --       (⟜-intro⁻
+--       --         (LinΣ-elim λ
+--       --         { (num x) → ⟜-intro {k = LinearΣ (Opening n)} (⊸-intro⁻ (⇒-intro⁻ (LinΣ-elim λ
+--       --           -- goto closing
+--       --           { (just RP) → ⇒-intro (⇐-intro⁻ (((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Opening n)} (LinΣ-intro b ∘g num ∘g LinΣ-intro x ,⊗ ⊕-inr))) ∘g &-π₁) ∘g &-π₂))
+--       --           ; nothing → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Opening n)} (LinΣ-intro b ∘g num ∘g LinΣ-intro x ,⊗ (⊕-inl ∘g ⊕-inl ,&p id)))) ∘g &-π₂ ∘g &-π₂))
+--       --           ; (just *) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Opening n)} (LinΣ-intro b ∘g num ∘g LinΣ-intro x ,⊗ (⊕-inl ∘g (⊕-inr ∘g ⊕-inl ,⊗ id) ,&p id)))) ∘g &-π₂ ∘g &-π₂))
+--       --           ; (just LP) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Opening n)} (LinΣ-intro b ∘g num ∘g LinΣ-intro x ,⊗ (⊕-inl ∘g (⊕-inr ∘g (⊕-inr ∘g ⊕-inl) ,⊗ id) ,&p id)))) ∘g &-π₂ ∘g &-π₂))
+--       --           ; (just (num y)) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Opening n)} (LinΣ-intro b ∘g num ∘g LinΣ-intro x ,⊗ (⊕-inl ∘g (⊕-inr ∘g (⊕-inr ∘g ⊕-inr ∘g LinΣ-intro y) ,⊗ id) ,&p id)))) ∘g &-π₂ ∘g &-π₂))
+--       --           }))
+--       --           ∘g id ,⊗ id ,&p LinΠ-app n)
+--       --           --  (⊸-intro⁻ (⇒-intro⁻ (LinΣ-elim λ
+--       --         ; LP → ⟜-intro {k = LinearΣ (Opening n)} (⊸-intro⁻ (((LinΣ-elim (λ b → ⊸-intro {k = LinearΣ (Opening n)} (LinΣ-intro b ∘g left)) ∘g &-π₁)) ∘g LinΠ-app (suc n) ∘g &-π₂))
+--       --         ; RP → ⟜-intro {k = LinearΣ (Opening n)} (LinΣ-intro false ∘g unexpected ∘g ⊕-inr ∘g ⊕-inl ,⊗ ⊤-intro)
+--       --         ; * → ⟜-intro {k = LinearΣ (Opening n)} (LinΣ-intro false ∘g unexpected ∘g ⊕-inr ∘g ⊕-inr ,⊗ ⊤-intro)
+--       --         })
+--       --       )
+--       --       -- ⟜-intro⁻
+--       --       ,& ⟜-intro⁻ (LinΣ-elim λ
+--       --        { RP → ⟜-intro {k = LinearΣ (Closing n)} (Nat.elim {A = λ n → Term (literal RP ⊗ Goal) (LinearΣ (Closing n))}
+--       --          -- empty stack
+--       --          (LinΣ-intro false ∘g rightUnmatched ∘g id ,⊗ ⊤-intro)
+--       --          -- popped
+--       --          (λ n-1 _ → (⊸-intro⁻ (⇒-intro⁻ (LinΣ-elim λ
+--       --            { (just RP) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Closing _)} (LinΣ-intro b ∘g rightClose ∘g id ,⊗ ⊕-inr))) ∘g &-π₁ ∘g &-π₂))
+--       --            ; nothing → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Closing _)} (LinΣ-intro b ∘g rightClose ∘g id ,⊗ (⊕-inl ∘g ⊕-inl ,&p id)))) ∘g &-π₂ ∘g &-π₂))
+--       --            ; (just *) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Closing _)} (LinΣ-intro b ∘g rightClose ∘g id ,⊗ (⊕-inl ∘g (⊕-inr ∘g ⊕-inl ,⊗ id) ,&p id)))) ∘g &-π₂ ∘g &-π₂))
+--       --            ; (just LP) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Closing _)} (LinΣ-intro b ∘g rightClose ∘g id ,⊗ (⊕-inl ∘g (⊕-inr ∘g (⊕-inr ∘g ⊕-inl) ,⊗ id) ,&p id)))) ∘g &-π₂ ∘g &-π₂))
+--       --            ; (just (num x)) → ⇒-intro (⇐-intro⁻ ((LinΣ-elim λ b → ⇐-intro (⊸-intro {k = LinearΣ (Closing _)} (LinΣ-intro b ∘g rightClose ∘g id ,⊗ (⊕-inl ∘g (⊕-inr ∘g (⊕-inr ∘g ⊕-inr ∘g LinΣ-intro x) ,⊗ id) ,&p id)))) ∘g &-π₂ ∘g &-π₂))
+--       --            })) ∘g id ,⊗ id ,&p LinΠ-app n-1))
+--       --          n)
+--       --        ; LP → ⟜-intro {k = LinearΣ (Closing n)} (LinΣ-intro false ∘g
+--       --          unexpected ∘g ⊕-inr ∘g (⊕-inr ∘g ⊕-inl) ,⊗ ⊤-intro)
+--       --        ; * → ⟜-intro {k = LinearΣ (Closing n)} (LinΣ-intro false ∘g
+--       --          unexpected ∘g ⊕-inr ∘g ⊕-inl ,⊗ ⊤-intro)
+--       --        ; (num x) → ⟜-intro {k = LinearΣ (Closing n)} (LinΣ-intro false ∘g
+--       --          unexpected ∘g ⊕-inr ∘g (⊕-inr ∘g ⊕-inr ∘g LinΣ-intro x) ,⊗ ⊤-intro)
+--       --        })
+--       --       ,&
+--       --      (⟜-intro⁻ (LinΣ-elim λ
+--       --        { * → ⟜-intro {k = LinearΣ (Multiplying n)} (⊸-intro⁻ ((((LinΣ-elim λ b → ⊸-intro {k = LinearΣ (Multiplying n)} (LinΣ-intro b ∘g times)) ∘g &-π₁) ∘g LinΠ-app n) ∘g &-π₂))
+--       --        ; LP → ⟜-intro {k = LinearΣ (Multiplying n)} (LinΣ-intro false ∘g unexpected ∘g ⊕-inl ,⊗ ⊤-intro)
+--       --        ; RP → ⟜-intro {k = LinearΣ (Multiplying n)} (LinΣ-intro false ∘g unexpected ∘g (⊕-inr ∘g ⊕-inl) ,⊗ ⊤-intro)
+--       --        ; (num x) → ⟜-intro {k = LinearΣ (Multiplying n)} (LinΣ-intro false ∘g unexpected ∘g (⊕-inr ∘g ⊕-inr ∘g LinΣ-intro x) ,⊗ ⊤-intro) }))
+--       --   })
 
--- -- Completeness i.e., that every LL(1) parse has a trace. Though
--- -- completeness would be that every LL(1) parse corresponds to one we
--- -- extract from the previous function
+-- --     parse : string ⊢ LinΣ[ b ∈ Bool ] Opening zero b
+-- --     parse = ((&-π₁ ∘g LinΠ-app zero) ∘g &-π₂) ∘g parse'
 
--- -- kind of would want a truly dependent linear type here
--- -- to formulate it that way...
--- module Completeness where
---   open LL⟨1⟩.Hom
---   mkTrace : LL⟨1⟩.Exp ⊢ Automaton.Opening 0 true
---   mkTrace = (⟜-app ∘g id ,⊗ (⊕-inl ∘g ⊕-inl ,& Automaton.done) ∘g ⊗-unit-r⁻) ∘g LinΠ-app 0 ∘g LL⟨1⟩.fold the-alg .fE where
---     open LL⟨1⟩.Algebra
---     the-alg : LL⟨1⟩.Algebra ℓ-zero
---     -- need to update the motive: a UAs should also produce a proof that it starts with ε or *
---     the-alg .UE = LinΠ[ n ∈ ℕ ] (Automaton.Opening n true ⟜ Automaton.DoneOpening n true)
---     the-alg .UAs = LinΠ[ n ∈ ℕ ] (Automaton.DoneOpening n true ⟜ Automaton.DoneOpening n true)
---     the-alg .UA = LinΠ[ n ∈ ℕ ] (Automaton.Opening n true ⟜ Automaton.DoneOpening n true)
---     the-alg .[mkExp] = LinΠ-intro λ n → ⟜-intro {k = Automaton.Opening n true}
---       (((⟜-app ∘g LinΠ-app n ,⊗ (⟜-app ∘g LinΠ-app n ,⊗ id)) ∘g ⊗-assoc⁻))
---     the-alg .[nil] = LinΠ-intro λ n → ⟜-intro-ε id
---     the-alg .[cons] = LinΠ-intro λ n → ⟜-intro {k = Automaton.DoneOpening n true}
---       (((((⊕-inl ∘g (⊕-inr ∘g ⊕-inl ,⊗ ⊤-intro) ,& Automaton.times) ∘g id ,⊗ ⟜-app) ∘g ⊗-assoc⁻) ∘g (id ,⊗ LinΠ-app n) ,⊗ (⟜-app ∘g LinΠ-app n ,⊗ id)) ∘g ⊗-assoc⁻)
---     the-alg .[num] {m} = LinΠ-intro λ n → ⟜-intro {k = Automaton.Opening n true}
---       (Automaton.num ∘g LinΣ-intro m ,⊗ id)
---     the-alg .[parens] = LinΠ-intro λ n → ⟜-intro {k = Automaton.Opening n true}
---       ((Automaton.left ∘g id ,⊗ (⟜-app {g = Automaton.Opening (suc n) true} ∘g LinΠ-app (suc n) ,⊗ (⊕-inr ∘g (id ,⊗ ⊤-intro) ,& Automaton.rightClose)∘g ⊗-assoc⁻)) ∘g ⊗-assoc⁻)
+-- -- -- Soundness: i.e., that from every trace we can extract an LL(1) parse
+-- -- module Soundness where
+-- --   buildExp : Automaton.Opening 0 true ⊢ LL⟨1⟩.Exp
+-- --   buildExp = ⊗-unit-r ∘g Automaton.Hom.fO (Automaton.fold alg) 0 where
+-- --     open LL⟨1⟩ using (Exp; Atom)
+-- --     open Automaton.Algebra
+-- --     Stk : ℕ → Grammar ℓ-zero
+-- --     Stk = Nat.elim ε
+-- --       (λ _ Stk⟨n⟩ → literal RP ⊗ KL* (literal * ⊗ Atom) ⊗ Stk⟨n⟩)
+-- --     alg : Automaton.Algebra ℓ-zero
+-- --     alg .UO n = Exp ⊗ Stk n
+-- --     alg .UC n = Stk n
+-- --     alg .UM n = KL* (literal * ⊗ Atom) ⊗ Stk n
+-- --     alg .[left] = ⊗-assoc ∘g ⟜3⊗ LL⟨1⟩.parens'
+-- --     alg .[num] {n} = ⊸-intro⁻ (⊕-elim
+-- --       -- the next thing was multiplying
+-- --       (⊸-intro {k = Exp ⊗ Stk n} (⊗-assoc ∘g (LinΣ-elim λ _ → Atom.num) ,⊗ &-π₂))
+-- --       -- the next thing was closing
+-- --       (⊸-intro {k = Exp ⊗ Stk n} ((LinΣ-elim λ _ → Atom.num ,⊗ nil ∘g ⊗-unit-r⁻) ,⊗ &-π₂)))
+-- --     alg .[rightClose] {n} = ⊸-intro⁻ (⊕-elim
+-- --       -- next is multiplying
+-- --       (⊸-intro {k = Stk (suc n)} (id ,⊗ &-π₂))
+-- --       -- next is more closing
+-- --       (⊸-intro {k = Stk (suc n)} (id ,⊗ (⟜0⊗ nil ∘g &-π₂))))
+-- --     alg .[times] = ⟜2⊗ cons' ∘g ⊗-assoc ∘g id ,⊗ ⊗-assoc⁻
+-- --     alg .[done] = ⟜0⊗ nil
+
+-- -- -- Completeness i.e., that every LL(1) parse has a trace. Though
+-- -- -- completeness would be that every LL(1) parse corresponds to one we
+-- -- -- extract from the previous function
+
+-- -- -- kind of would want a truly dependent linear type here
+-- -- -- to formulate it that way...
+-- -- module Completeness where
+-- --   open LL⟨1⟩.Hom
+-- --   mkTrace : LL⟨1⟩.Exp ⊢ Automaton.Opening 0 true
+-- --   mkTrace = (⟜-app ∘g id ,⊗ (⊕-inl ∘g ⊕-inl ,& Automaton.done) ∘g ⊗-unit-r⁻) ∘g LinΠ-app 0 ∘g LL⟨1⟩.fold the-alg .fE where
+-- --     open LL⟨1⟩.Algebra
+-- --     the-alg : LL⟨1⟩.Algebra ℓ-zero
+-- --     -- need to update the motive: a UAs should also produce a proof that it starts with ε or *
+-- --     the-alg .UE = LinΠ[ n ∈ ℕ ] (Automaton.Opening n true ⟜ Automaton.DoneOpening n true)
+-- --     the-alg .UAs = LinΠ[ n ∈ ℕ ] (Automaton.DoneOpening n true ⟜ Automaton.DoneOpening n true)
+-- --     the-alg .UA = LinΠ[ n ∈ ℕ ] (Automaton.Opening n true ⟜ Automaton.DoneOpening n true)
+-- --     the-alg .[mkExp] = LinΠ-intro λ n → ⟜-intro {k = Automaton.Opening n true}
+-- --       (((⟜-app ∘g LinΠ-app n ,⊗ (⟜-app ∘g LinΠ-app n ,⊗ id)) ∘g ⊗-assoc⁻))
+-- --     the-alg .[nil] = LinΠ-intro λ n → ⟜-intro-ε id
+-- --     the-alg .[cons] = LinΠ-intro λ n → ⟜-intro {k = Automaton.DoneOpening n true}
+-- --       (((((⊕-inl ∘g (⊕-inr ∘g ⊕-inl ,⊗ ⊤-intro) ,& Automaton.times) ∘g id ,⊗ ⟜-app) ∘g ⊗-assoc⁻) ∘g (id ,⊗ LinΠ-app n) ,⊗ (⟜-app ∘g LinΠ-app n ,⊗ id)) ∘g ⊗-assoc⁻)
+-- --     the-alg .[num] {m} = LinΠ-intro λ n → ⟜-intro {k = Automaton.Opening n true}
+-- --       (Automaton.num ∘g LinΣ-intro m ,⊗ id)
+-- --     the-alg .[parens] = LinΠ-intro λ n → ⟜-intro {k = Automaton.Opening n true}
+-- --       ((Automaton.left ∘g id ,⊗ (⟜-app {g = Automaton.Opening (suc n) true} ∘g LinΠ-app (suc n) ,⊗ (⊕-inr ∘g (id ,⊗ ⊤-intro) ,& Automaton.rightClose)∘g ⊗-assoc⁻)) ∘g ⊗-assoc⁻)

--- a/code/cubical/Examples/Dyck.agda
+++ b/code/cubical/Examples/Dyck.agda
@@ -44,16 +44,31 @@ open import Term Alphabet
 
 -- a simple, but ambiguous grammar for balanced parentheses
 data Dyck : Grammar ℓ-zero where
-  none : ε ⊢ Dyck
-  sequence  : Dyck ⊗ Dyck ⊢ Dyck
-  bracketed : literal [ ⊗ Dyck ⊗ literal ] ⊢ Dyck
+  none : ∀ w → ε w → Dyck w
+  sequence  : ∀ w →
+    Σ[ s ∈ Splitting w ]
+      Dyck (s .fst .fst) × Dyck (s .fst .snd) →
+    Dyck w
+  bracketed : ∀ w →
+    Σ[ s ∈ Splitting w ]
+      literal [ (s .fst .fst) ×
+      (Σ[ s' ∈ Splitting (s .fst .snd) ]
+        Dyck (s' .fst .fst) × (literal ]) (s' .fst .snd)) →
+    Dyck w
 
 -- Dyck grammar, an LL(0) grammar:
 -- S → ε
 --   | [ S ] S
 data Balanced : Grammar ℓ-zero where
-  nil : ε ⊢ Balanced
-  balanced : literal [ ⊗ Balanced ⊗ literal ] ⊗ Balanced ⊢ Balanced
+  nil : ∀ w → ε w → Balanced w
+  balanced : ∀ w →
+    Σ[ s ∈ Splitting w ]
+      literal [ (s .fst .fst) ×
+      (Σ[ s' ∈ Splitting (s .fst .snd) ]
+        Balanced (s' .fst .fst) ×
+          (Σ[ s'' ∈ Splitting (s' .fst .snd) ]
+            (literal ] )(s'' .fst .fst) × Balanced (s'' .fst .snd))) →
+    Balanced w
 
 module BALANCED where
   record Algebra ℓ : Type (ℓ-suc ℓ) where
@@ -63,10 +78,12 @@ module BALANCED where
       [balanced] : literal [ ⊗ U ⊗ literal ] ⊗ U ⊢ U
 
   open Algebra public
-  InitialAlgebra : Algebra _
-  InitialAlgebra .U = Balanced
-  InitialAlgebra .[nil] = nil
-  InitialAlgebra .[balanced] = balanced
+  opaque
+    unfolding _⊗_
+    InitialAlgebra : Algebra ℓ-zero
+    InitialAlgebra .U = Balanced
+    InitialAlgebra .[nil] = nil
+    InitialAlgebra .[balanced] = balanced
 
   record Hom {ℓ}{ℓ'} (G : Algebra ℓ)(H : Algebra ℓ') : Type (ℓ-max ℓ ℓ') where
     field
@@ -76,162 +93,204 @@ module BALANCED where
         fun ∘g G .[balanced] ≡ H .[balanced] ∘g (id ,⊗ fun ,⊗ id ,⊗ fun)
   open Hom public
 
-  idHom : {G : Algebra ℓg} → Hom G G
-  idHom .fun = λ w z → z
-  idHom .fun-nil = refl
-  idHom .fun-balanced = refl
+  opaque
+    unfolding ⊗-intro
+    idHom : {G : Algebra ℓg} → Hom G G
+    idHom .fun = λ w z → z
+    idHom .fun-nil = refl
+    idHom .fun-balanced = refl
 
-  _∘hom_ : ∀ {ℓ ℓ' ℓ''} {G : Algebra ℓ}{G' : Algebra ℓ'}{G'' : Algebra ℓ''}
-    → Hom G' G'' → Hom G G' → Hom G G''
-  (ϕ ∘hom ψ) .fun = ϕ .fun ∘g ψ .fun
-  (ϕ ∘hom ψ) .fun-nil = cong (ϕ .fun ∘g_) (ψ .fun-nil) ∙ ϕ .fun-nil
-  (ϕ ∘hom ψ) .fun-balanced =
-    cong (ϕ .fun ∘g_) (ψ .fun-balanced)
-    ∙ cong (_∘g id ,⊗ ψ .fun ,⊗ id ,⊗ ψ .fun) (ϕ .fun-balanced)
+    _∘hom_ : ∀ {ℓ ℓ' ℓ''} {G : Algebra ℓ}{G' : Algebra ℓ'}{G'' : Algebra ℓ''}
+      → Hom G' G'' → Hom G G' → Hom G G''
+    (ϕ ∘hom ψ) .fun = ϕ .fun ∘g ψ .fun
+    (ϕ ∘hom ψ) .fun-nil = cong (ϕ .fun ∘g_) (ψ .fun-nil) ∙ ϕ .fun-nil
+    (ϕ ∘hom ψ) .fun-balanced =
+      cong (ϕ .fun ∘g_) (ψ .fun-balanced)
+      ∙ cong (_∘g id ,⊗ ψ .fun ,⊗ id ,⊗ ψ .fun) (ϕ .fun-balanced)
 
-  {-# TERMINATING #-}
-  rec : ∀ (G : Algebra ℓg) → Hom InitialAlgebra G
-  rec G .fun = go where
-    go : Balanced ⊢ (U G)
-    go w (nil .w x) = [nil] G w x
-    go w (balanced .w x) = (G .[balanced] ∘g (id ,⊗ go ,⊗ id ,⊗ go)) w x
-  rec G .fun-nil = refl
-  rec G .fun-balanced = refl
+  opaque
+    unfolding _⊗_ InitialAlgebra
+    {-# TERMINATING #-}
+    rec : ∀ (G : Algebra ℓg) → Hom InitialAlgebra G
+    rec G .fun = go where
+      go : Balanced ⊢ (U G)
+      go w (nil .w x) = [nil] G w x
+      go w (balanced .w x) = (G .[balanced] ∘g (id ,⊗ go ,⊗ id ,⊗ go)) w x
+    rec G .fun-nil = refl
+    rec G .fun-balanced = refl
 
-  ind : ∀ {G : Algebra ℓg} → (ϕ : Hom InitialAlgebra G) → ϕ .fun ≡ rec G .fun
-  ind {G = G} ϕ = funExt λ w → funExt go where
-    go : ∀ {w} → (x : Balanced w) → ϕ .fun w x ≡ rec G .fun w x
-    go (nil _ x) = funExt⁻ (funExt⁻ (ϕ .fun-nil) _) _
-    go (balanced _ x) = funExt⁻ (funExt⁻ (ϕ .fun-balanced) _) _
-      -- lol, lmao even
-      ∙ λ i → G .[balanced] _
-      (x .fst ,
-       x .snd .fst ,
-       x .snd .snd .fst ,
-       go (x .snd .snd .snd .fst) i ,
-       x .snd .snd .snd .snd .fst ,
-       x .snd .snd .snd .snd .snd .fst ,
-       go (x .snd .snd .snd .snd .snd .snd) i)
+  opaque
+    unfolding literal _⊗_ ⊗-intro InitialAlgebra rec
+    ind : ∀ {G : Algebra ℓg} → (ϕ : Hom InitialAlgebra G) → ϕ .fun ≡ rec G .fun
+    ind {G = G} ϕ = funExt λ w → funExt go where
+      go : ∀ {w} → (x : Balanced w) → ϕ .fun w x ≡ rec G .fun w x
+      go (nil _ x) = funExt⁻ (funExt⁻ (ϕ .fun-nil) _) _
+      go (balanced _ x) = funExt⁻ (funExt⁻ (ϕ .fun-balanced) _) _
+        -- lol, lmao even
+        ∙ λ i → G .[balanced] _
+        (x .fst ,
+        x .snd .fst ,
+        x .snd .snd .fst ,
+        go (x .snd .snd .snd .fst) i ,
+        x .snd .snd .snd .snd .fst ,
+        x .snd .snd .snd .snd .snd .fst ,
+        go (x .snd .snd .snd .snd .snd .snd) i)
 
 data RR1 : Grammar ℓ-zero where
-  nil : ε ⊢ RR1
-  balanced : RR1 ⊗ literal [ ⊗ RR1 ⊗ literal ] ⊢ RR1
+  nil : ∀ w → ε w → RR1 w
+  balanced : ∀ w →
+    Σ[ s ∈ Splitting w ]
+      RR1 (s .fst .fst) ×
+      (Σ[ s' ∈ Splitting (s .fst .snd) ]
+        (literal [) (s' .fst .fst) ×
+          (Σ[ s'' ∈ Splitting (s' .fst .snd) ]
+            RR1 (s'' .fst .fst) × (literal ]) (s'' .fst .snd))) →
+    RR1 w
 
 data BalancedStk : ∀ (n : ℕ) → Grammar ℓ-zero where
-  eof : ε ⊢ BalancedStk zero
-  open[ : ∀ {n} → literal [ ⊗ BalancedStk (suc n) ⊢ BalancedStk n
-  close] : ∀ {n} → literal ] ⊗ BalancedStk n ⊢ BalancedStk (suc n)
-
+  eof : ∀ w → ε w → BalancedStk zero w
+  open[ : ∀ {n} w →
+    Σ[ s ∈ Splitting w ]
+      (literal [) (s .fst .fst) ×
+        BalancedStk (suc n) (s .fst .snd) →
+    BalancedStk n w
+  close] : ∀ {n} w →
+    Σ[ s ∈ Splitting w ]
+      (literal ]) (s .fst .fst) ×
+        BalancedStk n (s .fst .snd) →
+    BalancedStk (suc n) w
   -- these are the cases for failure
-  leftovers : ∀ {n} → ε ⊢ BalancedStk (suc n)
-  unexpected] : literal ] ⊗ ⊤ ⊢ BalancedStk 0
+  leftovers : ∀ {n} w → ε w → BalancedStk (suc n) w
+  unexpected] : ∀ w →
+    Σ[ s ∈ Splitting w ]
+      (literal ]) (s .fst .fst) ×
+         ⊤ (s .fst .snd) →
+    BalancedStk 0 w
 
-parseStk : string ⊢ LinΠ[ n ∈ ℕ ] BalancedStk n
-parseStk = foldKL*r _ (record
-  { the-ℓ = _ ; G = _
-  ; nil-case = LinΠ-intro λ { zero
-      → eof
-    ; (suc n)
-      → leftovers
-    }
-  ; cons-case = LinΠ-intro (λ n → ⟜-intro⁻ (LinΣ-elim (λ
-      { [ → ⟜-intro {k = BalancedStk _}
-        -- encountered an open paren, push onto the stack and continue
-        (open[ ∘g ⊗-intro id (LinΠ-app (suc n)))
-      ; ] → ⟜-intro {k = BalancedStk _} ((Nat.elim {A = λ n → _ ⊢ BalancedStk n}
-      -- the stack is empty but we encountered a close bracket
-      (unexpected] ∘g ⊗-intro id ⊤-intro)
-      -- the stack is suc n, continue with n
-      (λ n _ → close] ∘g ⊗-intro id (LinΠ-app n))
-      n))
-      })))
-  })
+opaque
+  unfolding _⊗_ ε
+  parseStk : string ⊢ LinΠ[ n ∈ ℕ ] BalancedStk n
+  parseStk = foldKL*r _ (record
+    { the-ℓ = _ ; G = _
+    ; nil-case = LinΠ-intro λ { zero
+        → eof
+      ; (suc n)
+        → leftovers
+      }
+    ; cons-case = LinΠ-intro (λ n → ⟜-intro⁻ (LinΣ-elim (λ
+        { [ → ⟜-intro {k = BalancedStk _}
+          -- encountered an open paren, push onto the stack and continue
+          (open[ ∘g ⊗-intro id (LinΠ-app (suc n)))
+        ; ] → ⟜-intro {k = BalancedStk _} ((Nat.elim {A = λ n → _ ⊢ BalancedStk n}
+        -- the stack is empty but we encountered a close bracket
+        (unexpected] ∘g ⊗-intro id ⊤-intro)
+        -- the stack is suc n, continue with n
+        (λ n _ → close] ∘g ⊗-intro id (LinΠ-app n))
+        n))
+        })))
+    })
 
 -- the n is the number of open parentheses that this datatype closes
 -- the bool is whether the trace is accepting or rejecting
 data BalancedStkTr : ∀ (n : ℕ) (b : Bool) → Grammar ℓ-zero where
-  eof : ε ⊢ BalancedStkTr zero true
+  eof : ∀ w → ε w → BalancedStkTr zero true w
 
-  open[ : ∀ {n b} → literal [ ⊗ BalancedStkTr (suc n) b ⊢ BalancedStkTr n b
-  close] : ∀ {n b} → literal ] ⊗ BalancedStkTr n b ⊢ BalancedStkTr (suc n) b
+  open[ : ∀ {n b} w →
+    Σ[ s ∈ Splitting w ]
+      (literal [) (s .fst .fst) ×
+        BalancedStkTr (suc n) b (s .fst .snd) →
+    BalancedStkTr n b w
+  close] : ∀ {n b} w →
+    Σ[ s ∈ Splitting w ]
+      (literal ]) (s .fst .fst) ×
+        BalancedStkTr n b (s .fst .snd) →
+    BalancedStkTr (suc n) b w
 
-  leftovers : ∀ {n} → ε ⊢ BalancedStkTr (suc n) false
-  unexpected] : literal ] ⊗ ⊤ ⊢ BalancedStkTr 0 false
+  leftovers : ∀ {n} w → ε w → BalancedStkTr (suc n) false w
+  unexpected] : ∀ w →
+    Σ[ s ∈ Splitting w ]
+      (literal ]) (s .fst .fst) ×
+        ⊤ (s .fst .snd) →
+    BalancedStkTr 0 false w
 
-parseStkTr : string ⊢ LinΠ[ n ∈ ℕ ] LinΣ[ b ∈ Bool ] BalancedStkTr n b
-parseStkTr = foldKL*r _ (record { the-ℓ = _ ; G = _
-  ; nil-case = LinΠ-intro (λ
-    { zero → LinΣ-intro true ∘g eof
-    ; (suc n) → LinΣ-intro false ∘g leftovers })
-  ; cons-case = LinΠ-intro (λ n → ⟜-intro⁻ (LinΣ-elim (λ
-    { [ → ⟜-intro {k = Motive n}
-        (⊸-intro⁻ (LinΣ-elim
-          (λ b → ⊸-intro {k = Motive n} (LinΣ-intro b ∘g open[))) ∘g
-            ⊗-intro id (LinΠ-app (suc n)))
-    ; ] → ⟜-intro {k = Motive n}
-        (Nat.elim {A = λ n → _ ⊢ Motive n}
-          (LinΣ-intro false ∘g unexpected] ∘g ⊗-intro id ⊤-intro)
-          (λ n-1 _ →
-        ⊸-intro⁻ (LinΣ-elim (λ b → ⊸-intro {k = Motive (suc n-1)}
-          (LinΣ-intro b ∘g close]))
-        ∘g LinΠ-app n-1))
-          n)
-    })))
-  })
-  where
-    Motive : ℕ → Grammar _
-    Motive = λ n → LinΣ[ b ∈ Bool ] BalancedStkTr n b
+opaque
+  unfolding _⊗_
+  parseStkTr : string ⊢ LinΠ[ n ∈ ℕ ] LinΣ[ b ∈ Bool ] BalancedStkTr n b
+  parseStkTr = foldKL*r _ (record { the-ℓ = ℓ-zero ; G = _
+    ; nil-case = LinΠ-intro (λ
+      { zero → LinΣ-intro true ∘g eof
+      ; (suc n) → LinΣ-intro false ∘g leftovers })
+    ; cons-case = LinΠ-intro (λ n → ⟜-intro⁻ (LinΣ-elim (λ
+      { [ → ⟜-intro {k = Motive n}
+          (⊸-intro⁻ (LinΣ-elim
+            (λ b → ⊸-intro {k = Motive n} (LinΣ-intro b ∘g open[))) ∘g
+              ⊗-intro id (LinΠ-app (suc n)))
+      ; ] → ⟜-intro {k = Motive n}
+          (Nat.elim {A = λ n → _ ⊢ Motive n}
+            (LinΣ-intro false ∘g unexpected] ∘g ⊗-intro id ⊤-intro)
+            (λ n-1 _ →
+          ⊸-intro⁻ (LinΣ-elim (λ b → ⊸-intro {k = Motive (suc n-1)}
+            (LinΣ-intro b ∘g close]))
+          ∘g LinΠ-app n-1))
+            n)
+      })))
+    })
+    where
+      Motive : ℕ → Grammar ℓ-zero
+      Motive = λ n → LinΣ[ b ∈ Bool ] BalancedStkTr n b
 
--- alternative: define this function by recursion
--- decide : ∀ n → BalancedStk n ⊢ LinΣ[ b ∈ Bool ] BalancedStkTr n b
--- decide = {!!}
+  -- alternative: define this function by recursion
+  -- decide : ∀ n → BalancedStk n ⊢ LinΣ[ b ∈ Bool ] BalancedStkTr n b
+  -- decide = {!!}
 
--- to turn an LL(0) tree of balanced parens into a trace, turn each
--- subtree into a function that appends onto a balanced stack trace of
--- arbitrary state without changing it.
-exhibitTrace : Balanced ⊢ BalancedStkTr zero true
-exhibitTrace =
-  (((⟜-app ∘g id ,⊗ eof) ∘g ⊗-unit-r⁻) ∘g LinΠ-app zero)
-  ∘g BALANCED.fun (BALANCED.rec alg)
-  where
-  alg : BALANCED.Algebra _
-  alg .BALANCED.U = LinΠ[ n ∈ ℕ ] (BalancedStkTr n true ⟜ BalancedStkTr n true)
-  alg .BALANCED.[nil] = LinΠ-intro λ n → ⟜-intro-ε id
-  alg .BALANCED.[balanced] = LinΠ-intro λ n → ⟜-intro {k = BalancedStkTr n true}
-    ((open[ ∘g ⊗-intro id (⟜-app ∘g ⊗-intro (LinΠ-app (suc n)) (close]
-    ∘g ⊗-intro id (⟜-app ∘g ⊗-intro (LinΠ-app n) id) ∘g ⊗-assoc⁻) ∘g ⊗-assoc⁻))
-    ∘g ⊗-assoc⁻)
+  -- to turn an LL(0) tree of balanced parens into a trace, turn each
+  -- subtree into a function that appends onto a balanced stack trace of
+  -- arbitrary state without changing it.
+  opaque
+    unfolding BALANCED.InitialAlgebra
+    exhibitTrace : Balanced ⊢ BalancedStkTr zero true
+    exhibitTrace =
+      (((⟜-app ∘g id ,⊗ eof) ∘g ⊗-unit-r⁻) ∘g LinΠ-app zero)
+      ∘g BALANCED.fun (BALANCED.rec alg)
+      where
+      alg : BALANCED.Algebra ℓ-zero
+      alg .BALANCED.U = LinΠ[ n ∈ ℕ ] (BalancedStkTr n true ⟜ BalancedStkTr n true)
+      alg .BALANCED.[nil] = LinΠ-intro λ n → ⟜-intro-ε id
+      alg .BALANCED.[balanced] = LinΠ-intro λ n → ⟜-intro {k = BalancedStkTr n true}
+        ((open[ ∘g ⊗-intro id (⟜-app ∘g ⊗-intro (LinΠ-app (suc n)) (close]
+        ∘g ⊗-intro id (⟜-app ∘g ⊗-intro (LinΠ-app n) id) ∘g ⊗-assoc⁻) ∘g ⊗-assoc⁻))
+        ∘g ⊗-assoc⁻)
 
--- to translate from BST(0) to S we need to generalize the inductive hypothesis
--- and pick a motive for BST(n) such that we can extract an S from a BST(0).
---
--- Idea: BST(n) is a term with some balanced parens, but n unmatched ]'s in it.
--- We can define this as an alternating sequence of S and ] with n ]'s in it:
---     S (] S)^n
--- We can view this as a "stack" of parses marked by ] "delimiters"
--- mkParseTree : BalancedStkTr zero true ⊢ Balanced
--- mkParseTree = {!!} where
---   Stk : ℕ → Grammar _
---   Stk = Nat.elim ε-grammar λ _ Stk⟨n⟩ → literal ] ⊗ Balanced ⊗ Stk⟨n⟩
---   -- our state is a "current" Balanced expr that we are building, as
---   -- well as a stack of ]-separated balanced exprs that are waiting to
---   -- be completed
---   Motive : ℕ → Grammar _
---   Motive n = Balanced ⊗ Stk n
---   -- we initialize the current expression to be the empty parse
---   [eof] : ε-grammar ⊢ Motive zero
---   [eof] = ⊗-intro nil id ∘g ⊗-unit-l⁻
---   -- when we see a close paren, we push it and the current expression
---   -- onto the stack and initialize the new current exp to be empty
---   [close] : ∀ {n} → literal ] ⊗ Motive n ⊢ Motive (suc n)
---   [close] {n} = ⊗-intro nil id ∘g ⊗-unit-l⁻
---   -- when we see an open paren, we combine the current balanced exp
---   -- with the top frame which we pop off of the stack
---   [open] : ∀ {n} → literal [ ⊗ Motive (suc n) ⊢ Motive n
---   [open] = ⊗-intro balanced id ∘g ⊗-assoc ∘g
---     ⊗-intro id (⊗-assoc ∘g ⊗-intro id ⊗-assoc)
+  -- to translate from BST(0) to S we need to generalize the inductive hypothesis
+  -- and pick a motive for BST(n) such that we can extract an S from a BST(0).
+  --
+  -- Idea: BST(n) is a term with some balanced parens, but n unmatched ]'s in it.
+  -- We can define this as an alternating sequence of S and ] with n ]'s in it:
+  --     S (] S)^n
+  -- We can view this as a "stack" of parses marked by ] "delimiters"
+  -- mkParseTree : BalancedStkTr zero true ⊢ Balanced
+  -- mkParseTree = {!!} where
+  --   Stk : ℕ → Grammar _
+  --   Stk = Nat.elim ε-grammar λ _ Stk⟨n⟩ → literal ] ⊗ Balanced ⊗ Stk⟨n⟩
+  --   -- our state is a "current" Balanced expr that we are building, as
+  --   -- well as a stack of ]-separated balanced exprs that are waiting to
+  --   -- be completed
+  --   Motive : ℕ → Grammar _
+  --   Motive n = Balanced ⊗ Stk n
+  --   -- we initialize the current expression to be the empty parse
+  --   [eof] : ε-grammar ⊢ Motive zero
+  --   [eof] = ⊗-intro nil id ∘g ⊗-unit-l⁻
+  --   -- when we see a close paren, we push it and the current expression
+  --   -- onto the stack and initialize the new current exp to be empty
+  --   [close] : ∀ {n} → literal ] ⊗ Motive n ⊢ Motive (suc n)
+  --   [close] {n} = ⊗-intro nil id ∘g ⊗-unit-l⁻
+  --   -- when we see an open paren, we combine the current balanced exp
+  --   -- with the top frame which we pop off of the stack
+  --   [open] : ∀ {n} → literal [ ⊗ Motive (suc n) ⊢ Motive n
+  --   [open] = ⊗-intro balanced id ∘g ⊗-assoc ∘g
+  --     ⊗-intro id (⊗-assoc ∘g ⊗-intro id ⊗-assoc)
 
---   done : Motive 0 ⊢ Balanced
---   done = ⊗-unit-r
+  --   done : Motive 0 ⊢ Balanced
+  --   done = ⊗-unit-r
 
--- -- TODO: show this is a *strong* equivalence!
+  -- -- TODO: show this is a *strong* equivalence!

--- a/code/cubical/Grammar/Equivalence/Combinators.agda
+++ b/code/cubical/Grammar/Equivalence/Combinators.agda
@@ -29,13 +29,15 @@ module _
 
   open StrongEquivalence
 
-  concat-strong-equiv : StrongEquivalence (g ⊗ k) (h ⊗ l)
-  concat-strong-equiv .fun =
-    ⊗-intro (g≅h .fun) (k≅l .fun)
-  concat-strong-equiv .inv =
-    ⊗-intro (g≅h .inv) (k≅l .inv)
-  concat-strong-equiv .sec i = ⊗-intro (g≅h .sec i) (k≅l .sec i)
-  concat-strong-equiv .ret i = ⊗-intro (g≅h .ret i) (k≅l .ret i)
+  opaque
+    unfolding _⊗_ ⊗-intro
+    concat-strong-equiv : StrongEquivalence (g ⊗ k) (h ⊗ l)
+    concat-strong-equiv .fun =
+      ⊗-intro (g≅h .fun) (k≅l .fun)
+    concat-strong-equiv .inv =
+      ⊗-intro (g≅h .inv) (k≅l .inv)
+    concat-strong-equiv .sec i = ⊗-intro (g≅h .sec i) (k≅l .sec i)
+    concat-strong-equiv .ret i = ⊗-intro (g≅h .ret i) (k≅l .ret i)
 
   opaque
     unfolding ⊕-inl
@@ -58,34 +60,39 @@ module _
 
   open StrongEquivalence
 
-  the-g*-alg : *r-Algebra g
-  the-g*-alg =
-    (record { the-ℓ = _
-            ; G = KL* h
-            ; nil-case = nil
-            ; cons-case = cons ∘g ⊗-intro (g≅h .fun) id })
+  opaque
+    unfolding ⊗-intro
+    the-g*-alg : *r-Algebra g
+    the-g*-alg =
+      (record { the-ℓ = _
+              ; G = KL* h
+              ; nil-case = nil
+              ; cons-case = cons ∘g ⊗-intro (g≅h .fun) id })
 
-  the-h*-alg : *r-Algebra h
-  the-h*-alg =
-    (record { the-ℓ = _
-            ; G = KL* g
-            ; nil-case = nil
-            ; cons-case = cons ∘g ⊗-intro (g≅h .inv) id })
+    the-h*-alg : *r-Algebra h
+    the-h*-alg =
+      (record { the-ℓ = _
+              ; G = KL* g
+              ; nil-case = nil
+              ; cons-case = cons ∘g ⊗-intro (g≅h .inv) id })
 
   opaque
+    unfolding the-g*-alg *r-initial KL*r-elim id*r-AlgebraHom
     star-strong-equiv : StrongEquivalence (KL* g) (KL* h)
     star-strong-equiv .fun = foldKL*r g the-g*-alg
     star-strong-equiv .inv = foldKL*r h the-h*-alg
     star-strong-equiv .sec =
-      !*r-AlgebraHom' h (*r-initial h)
-        (record { f = foldKL*r g the-g*-alg ∘g foldKL*r h the-h*-alg
-                ; on-nil = refl
-                ; on-cons =
-                  λ i → cons ∘g ⊗-intro (g≅h .sec i) id ∘g
-                    ⊗-intro id (foldKL*r g the-g*-alg ∘g foldKL*r h the-h*-alg) })
+      !*r-AlgebraHom h (*r-initial h)
+        (record {
+          f = foldKL*r g the-g*-alg ∘g foldKL*r h the-h*-alg
+        ; on-nil = refl
+        ; on-cons =
+          λ i → cons ∘g ⊗-intro (g≅h .sec i) id ∘g
+            ⊗-intro id (foldKL*r g the-g*-alg ∘g foldKL*r h the-h*-alg)
+        })
         (id*r-AlgebraHom h (*r-initial h))
     star-strong-equiv .ret =
-      !*r-AlgebraHom' g (*r-initial g)
+      !*r-AlgebraHom g (*r-initial g)
         (record { f = foldKL*r h the-h*-alg ∘g foldKL*r g the-g*-alg
                 ; on-nil = refl
                 ; on-cons =

--- a/code/cubical/Grammar/KleeneStar.agda
+++ b/code/cubical/Grammar/KleeneStar.agda
@@ -20,12 +20,8 @@ private
 module _ (g : Grammar ℓG) where
   data KL* : Grammar ℓG
     where
-    nil : ∀ w → ε w → KL* w
-    cons : ∀ w →
-      Σ[ s ∈ Splitting w ]
-       g (s .fst .fst) × KL* (s .fst .snd) →
-      KL* w
-
+    nil : ε ⊢ KL*
+    cons : g ⊗' KL* ⊢ KL*
 
   -- I want a non-recursive way to check that a Kleene star is either nil
   -- or cons

--- a/code/cubical/Grammar/LinearFunction.agda
+++ b/code/cubical/Grammar/LinearFunction.agda
@@ -23,6 +23,7 @@ private
     l : Grammar ℓl
 
 opaque
+  unfolding _⊗_
   _⊸_ : Grammar ℓg → Grammar ℓh → Grammar (ℓ-max ℓg ℓh)
   (g ⊸ h) w = ∀ (w' : String) → g w' → h (w' ++ w)
 
@@ -73,7 +74,7 @@ opaque
   ⊸-app ∘g (⊗-intro (id {g = h}) f)
 
 opaque
-  unfolding _⊸_
+  unfolding _⊸_ _⊗_ ⊗-intro
   ⊸-intro∘⊸-intro⁻≡id :
     (e : g ⊢ h ⊸ k) →
     ⊸-intro {g = h}{h = g}{k = k}(⊸-intro⁻ e) ≡ e

--- a/code/cubical/Grammar/LinearProduct.agda
+++ b/code/cubical/Grammar/LinearProduct.agda
@@ -19,9 +19,12 @@ private
     k : Grammar ℓk
     l : Grammar ℓl
 
+_⊗'_ : Grammar ℓg → Grammar ℓh → Grammar (ℓ-max ℓg ℓh)
+(g ⊗' g') w = Σ[ s ∈ Splitting w ] g (s .fst .fst) × g' (s .fst .snd)
+infixr 5 _⊗'_
 opaque
   _⊗_ : Grammar ℓg → Grammar ℓh → Grammar (ℓ-max ℓg ℓh)
-  (g ⊗ g') w = Σ[ s ∈ Splitting w ] g (s .fst .fst) × g' (s .fst .snd)
+  _⊗_ = _⊗'_
 infixr 5 _⊗_
 
 opaque

--- a/code/cubical/Grammar/LinearProduct.agda
+++ b/code/cubical/Grammar/LinearProduct.agda
@@ -19,11 +19,13 @@ private
     k : Grammar ℓk
     l : Grammar ℓl
 
-_⊗_ : Grammar ℓg → Grammar ℓh → Grammar (ℓ-max ℓg ℓh)
-(g ⊗ g') w = Σ[ s ∈ Splitting w ] g (s .fst .fst) × g' (s .fst .snd)
+opaque
+  _⊗_ : Grammar ℓg → Grammar ℓh → Grammar (ℓ-max ℓg ℓh)
+  (g ⊗ g') w = Σ[ s ∈ Splitting w ] g (s .fst .fst) × g' (s .fst .snd)
 infixr 5 _⊗_
 
 opaque
+  unfolding _⊗_
   ⊗-elim : g ,, h ⊢ k → g ⊗ h ⊢ k
   ⊗-elim {k = k} f w (((w1 , w2) , w≡w1++w2) , gp , hp) =
     subst k (sym w≡w1++w2) (f w1 w2 gp hp)
@@ -39,253 +41,275 @@ opaque
   --   → f ≡ ⊗-elim {k = k} (f ∘b ⊗-intro')
   -- ⊗-η f i w x = {!!}
 
-⊗PathP : {g : I → Grammar ℓg}{h : I → Grammar ℓh}
-  {w : I → String}
-  → {p : (g i0 ⊗ h i0) (w i0)}
-  → {q : (g i1 ⊗ h i1) (w i1)}
-  → (s≡ : p .fst .fst ≡ q .fst .fst)
-  → PathP (λ i → g i (s≡ i .fst) × h i (s≡ i .snd)) (p .snd) (q .snd)
-  → PathP (λ i → (g i ⊗ h i) (w i)) p q
-⊗PathP s≡ p≡ = ΣPathP (SplittingPathP s≡ , p≡)
+  -- because ⊗ is opaque,
+  -- same-splits and same-parses are needed so that the interface of
+  -- ⊗ doesn't leak in the type signature of ⊗PathP
+  same-splits :
+    {g : I → Grammar ℓg}{h : I → Grammar ℓh}
+    {w : I → String}
+    → (p : (g i0 ⊗ h i0) (w i0))
+    → (q : (g i1 ⊗ h i1) (w i1))
+    → Type ℓ-zero
+  same-splits p q = p .fst .fst ≡ q .fst .fst
 
-⊗≡ : ∀ {g : Grammar ℓg}{h : Grammar ℓh}{w}
-  → (p p' : (g ⊗ h) w)
-  → (s≡ : p .fst .fst ≡ p' .fst .fst)
-  → PathP (λ i → g (s≡ i .fst) × h (s≡ i .snd)) (p .snd) (p' .snd)
-  → p ≡ p'
-⊗≡ p p' s≡ p≡ = ⊗PathP s≡ p≡
+  same-parses :
+    {g : I → Grammar ℓg}{h : I → Grammar ℓh}
+    {w : I → String}
+    → (p : (g i0 ⊗ h i0) (w i0))
+    → (q : (g i1 ⊗ h i1) (w i1))
+    → (s≡ : same-splits {g = g}{h = h}{w = w} p q)
+    → Type (ℓ-max ℓg ℓh)
+  same-parses {g = g} {h = h} p q s≡ =
+    PathP (λ i → g i (s≡ i .fst) × h i (s≡ i .snd)) (p .snd) (q .snd)
 
-⊗-intro :
-  g ⊢ h →
-  k ⊢ l →
-  g ⊗ k ⊢ h ⊗ l
-⊗-intro e e' _ p =
-  p .fst , (e _ (p .snd .fst)) , (e' _ (p .snd .snd))
+  ⊗PathP :
+    {g : I → Grammar ℓg}{h : I → Grammar ℓh}
+    {w : I → String}
+    → {p : (g i0 ⊗ h i0) (w i0)}
+    → {q : (g i1 ⊗ h i1) (w i1)}
+    → (s≡ : same-splits {g = g} {h = h} {w = w} p q)
+    → same-parses p q s≡
+    → PathP (λ i → (g i ⊗ h i) (w i)) p q
+  ⊗PathP s≡ p≡ = ΣPathP (SplittingPathP s≡ , p≡)
+
+  ⊗≡ : ∀ {g : Grammar ℓg}{h : Grammar ℓh}{w}
+    → (p p' : (g ⊗ h) w)
+    → (s≡ : same-splits {g = λ _ → g}{h = λ _ → h}{w = λ _ → w} p p')
+    → same-parses p p' s≡
+    → p ≡ p'
+  ⊗≡ p p' s≡ p≡ = ⊗PathP s≡ p≡
+
+  ⊗-intro :
+    g ⊢ h →
+    k ⊢ l →
+    g ⊗ k ⊢ h ⊗ l
+  ⊗-intro e e' _ p =
+    p .fst , (e _ (p .snd .fst)) , (e' _ (p .snd .snd))
+
+  opaque
+    unfolding ε
+    ⊗-unit-r :
+      g ⊗ ε ⊢ g
+    ⊗-unit-r {g = g} _ (((w' , []') , w≡w'++[]') , p⟨w'⟩ , []'≡[]) =
+      subst g (sym (++-unit-r _)
+              ∙ cong (w' ++_) (sym []'≡[])
+              ∙ sym w≡w'++[]')
+            p⟨w'⟩
+
+    ⊗-unit-r⁻ :
+      g ⊢ g ⊗ ε
+    ⊗-unit-r⁻ _ p =
+      ((_ , []) , (sym (++-unit-r _))) , (p , refl)
+
+    isPropε : ∀ w → isProp (ε w)
+    isPropε w = isSetString _ _
+
+    rectify :
+      ∀ {w w'}{g : Grammar ℓg}
+      → {p : g w}{q : g w'}
+      → {w≡ w≡' : w ≡ w'}
+      → PathP (λ i → g (w≡  i)) p q
+      → PathP (λ i → g (w≡' i)) p q
+    rectify {w = w}{w'}{g = g}{p = p}{q = q} =
+      subst {A = w ≡ w'} (λ w≡ → PathP (λ i → g (w≡ i)) p q)
+        (isSetString _ _ _ _)
+
+    ⊗-unit-rr⁻ :
+      ∀ {g : Grammar ℓg}
+      → ⊗-unit-r⁻ {g = g} ∘g ⊗-unit-r ≡ id
+    ⊗-unit-rr⁻ {g = g} =
+      funExt λ w → funExt λ (((w' , []') , w≡w'++[]') , p⟨w'⟩ , []'≡[]) →
+      let w≡w' = (sym (sym (++-unit-r _)
+              ∙ cong (w' ++_) (sym []'≡[])
+              ∙ sym w≡w'++[]'))
+      in
+      ⊗≡ _ _
+        (≡-× w≡w'
+          (sym []'≡[]))
+        (ΣPathP
+          ( symP (subst-filler g (sym w≡w') p⟨w'⟩)
+          , isProp→PathP (λ _ → isPropε _) refl []'≡[]))
+
+    ⊗-unit-r⁻r : ∀ {g : Grammar ℓg}
+      → ⊗-unit-r {g = g} ∘g ⊗-unit-r⁻ ≡ id
+    ⊗-unit-r⁻r {g = g} = funExt λ w → funExt λ p →
+      let
+        w≡w : w ≡ w
+        w≡w =       (λ i →
+             (hcomp
+              (doubleComp-faces (λ _ → w)
+               (λ i₁ →
+                  hcomp (doubleComp-faces (λ _ → w ++ [])
+                    (λ i₂ → ++-unit-r w i₂) i₁)
+                  (w ++ []))
+               i)
+              (++-unit-r w (~ i))))
+      in
+      subst (λ w≡w → subst g w≡w p ≡ p) (isSetString _ _ refl w≡w)
+        (substRefl {B = g} p)
+
+    ⊗-unit-l :
+      ε ⊗ g ⊢ g
+    ⊗-unit-l {g = g} _ p =
+      transport
+        (cong g (cong (_++  p .fst .fst .snd)
+          (sym (p .snd .fst)) ∙ sym (p .fst .snd)))
+        (p .snd .snd)
+
+    ⊗-unit-l⁻ :
+      g ⊢ ε ⊗ g
+    ⊗-unit-l⁻ _ p =
+      (([] , _) , refl) , (refl , p)
+
+    ⊗-unit-ll⁻ :
+      ⊗-unit-l⁻ {g = g} ∘g ⊗-unit-l ≡ id
+    ⊗-unit-ll⁻ {g = g} = funExt λ w → funExt λ p⊗ →
+      let
+        w'≡w : p⊗ .fst .fst .snd ≡ w
+        w'≡w =
+          (λ i →
+              (hcomp
+               (doubleComp-faces (λ _ → p⊗ .fst .fst .snd)
+                (λ i₁ → p⊗ .fst .snd (~ i₁)) i)
+               (p⊗ .snd .fst (~ i) ++ p⊗ .fst .fst .snd)))
+        in
+       ⊗≡ _ _
+         (≡-× (sym (p⊗ .snd .fst)) (sym w'≡w))
+         (ΣPathP ((isProp→PathP (λ i → isSetString _ _) _ _) ,
+         symP (subst-filler g w'≡w (p⊗ .snd .snd))))
+
+    ⊗-unit-l⁻l :
+      ⊗-unit-l {g = g} ∘g ⊗-unit-l⁻ ≡ id
+    ⊗-unit-l⁻l {g = g} = funExt λ w → funExt λ p →
+      let w≡w = λ i →
+                   ((λ i₁ →
+                       ⊗-unit-l⁻ {g = g} w p .snd .fst (~ i₁) ++
+                         ⊗-unit-l⁻ {g = g} w p .fst .fst .snd)
+                    ∙ (λ i₁ → ⊗-unit-l⁻ {g = g} w p .fst .snd (~ i₁)))
+                   i
+      in
+      subst (λ w≡w → subst g w≡w p ≡ p)
+        (isSetString _ _ refl w≡w) (substRefl {B = g} p)
+
+    cong-∘g⊗-unit-l⁻ :
+      (e e' : ε ⊗ g ⊢ h) →
+      (e ∘g ⊗-unit-l⁻ ≡ e' ∘g ⊗-unit-l⁻) →
+      e ≡ e'
+    cong-∘g⊗-unit-l⁻ f g ∘g≡ =
+      cong (f ∘g_) (sym ⊗-unit-ll⁻) ∙
+      cong (_∘g ⊗-unit-l) ∘g≡ ∙
+      cong (g ∘g_) (⊗-unit-ll⁻)
+
+    cong-∘g⊗-unit-r⁻ :
+      (e e' : g ⊗ ε ⊢ h) →
+      (e ∘g ⊗-unit-r⁻ ≡ e' ∘g ⊗-unit-r⁻) →
+      e ≡ e'
+    cong-∘g⊗-unit-r⁻ f g ∘g≡ =
+      cong (f ∘g_) (sym ⊗-unit-rr⁻) ∙
+      cong (_∘g ⊗-unit-r) ∘g≡ ∙
+      cong (g ∘g_) (⊗-unit-rr⁻)
+
+    -- TODO this proof seems overly complicated
+    ⊗-unit-r⊗-intro :
+      (f : g ⊢ h) →
+      ⊗-unit-r ∘g ⊗-intro f id ≡ f ∘g ⊗-unit-r
+    ⊗-unit-r⊗-intro f =
+      cong-∘g⊗-unit-r⁻ (⊗-unit-r ∘g ⊗-intro f id) (f ∘g ⊗-unit-r)
+        ((⊗-unit-r ∘g ⊗-intro f id) ∘g ⊗-unit-r⁻
+          ≡⟨ refl ⟩
+          ⊗-unit-r ∘g ⊗-unit-r⁻ ∘g f
+          ≡⟨ ((λ i → ⊗-unit-r⁻r i ∘g f ∘g ⊗-unit-r⁻r (~ i))) ⟩
+        (f ∘g ⊗-unit-r) ∘g ⊗-unit-r⁻
+        ∎)
+        -- (cong (_∘g f) {!sym ⊗-unit-rr⁻!})
+      -- ⊗-unit-r ∘g ⊗-intro f id
+      --   ≡⟨ {!cong-∘g⊗-unit-r!} ⟩
+      -- f ∘g ⊗-unit-r
+      -- ∎
+
+    ⊗-unit-rl⁻ : ⊗-unit-r ∘g ⊗-unit-l⁻ ≡ id
+    ⊗-unit-rl⁻ = funExt λ w → funExt λ p →
+      isSetString w [] ((⊗-unit-r ∘g ⊗-unit-l⁻) w p) (id {g = ε} w p)
+
+  ⊗-unit-r' :
+    g ⊗ ε ⊢ g
+  ⊗-unit-r' = ⊗-elim (ε-elim-r id)
+
+  ⊗-unit-r'⁻ : g ⊢ g ⊗ ε
+  ⊗-unit-r'⁻ = ⊗-intro' b∘εr ε-intro
+
+  ⊗-assoc :
+    g ⊗ (h ⊗ k) ⊢ (g ⊗ h) ⊗ k
+  ⊗-assoc _ p =
+    ((fst p .fst .fst ++ fst (p .snd .snd) .fst .fst ,
+      fst (p .snd .snd) .fst .snd) ,
+      p .fst .snd ∙
+      cong (p .fst .fst .fst ++_) (p .snd .snd .fst .snd) ∙
+      sym
+      (++-assoc
+        (p .fst .fst .fst)
+        (p .snd .snd .fst .fst .fst)
+        (p .snd .snd .fst .fst .snd))) ,
+    ((((fst p .fst .fst , fst (p .snd .snd) .fst .fst) ,
+      refl) ,
+    ((p .snd .fst) , (p .snd .snd .snd .fst))) , (p .snd .snd .snd .snd))
+
+  ⊗-assoc⁻ :
+    (g ⊗ h) ⊗ k ⊢ g ⊗ (h ⊗ k)
+  ⊗-assoc⁻ _ p =
+    (((fst (p .snd .fst) .fst .fst) ,
+      (fst (p .snd .fst) .fst .snd ++ fst p .fst .snd)) ,
+      (p .fst .snd ∙
+      cong (_++ p .fst .fst .snd) (p .snd .fst .fst .snd) ∙
+      ++-assoc
+        (p .snd .fst .fst .fst .fst)
+        (p .snd .fst .fst .fst .snd)
+        (p .fst .fst .snd))) ,
+      (p .snd .fst .snd .fst ,
+      ((_ , refl) ,
+      (p .snd .fst .snd .snd ,
+      p .snd .snd)))
+
+  ⊗-assoc∘⊗-assoc⁻≡id :
+   ⊗-assoc {g = g}{h = h}{k = k} ∘g ⊗-assoc⁻ ≡ id
+  ⊗-assoc∘⊗-assoc⁻≡id = funExt λ w → funExt λ p →
+    ⊗≡ _ _
+      (≡-× (λ i → p .snd .fst .fst .snd (~ i)) refl)
+      (ΣPathP (
+        (⊗PathP
+          (≡-× refl refl)
+          (≡-× refl refl)) ,
+        refl))
+
+  ⊗-assoc⁻∘⊗-assoc≡id :
+   ⊗-assoc⁻ {g = g}{h = h}{k = k} ∘g ⊗-assoc ≡ id
+  ⊗-assoc⁻∘⊗-assoc≡id = funExt λ w → funExt λ p →
+    ⊗≡ _ _
+      (≡-× refl (sym (p .snd .snd .fst .snd)))
+      (ΣPathP (
+        refl ,
+        (⊗PathP (≡-× refl refl)
+          (ΣPathP (refl , refl)))))
+
+  ⊗-assoc⁻⊗-intro :
+    ∀ {f : g ⊢ h}{f' : g' ⊢ h'}{f'' : g'' ⊢ h''}
+    → ⊗-assoc⁻ ∘g (⊗-intro (⊗-intro f f') f'')
+    ≡ ⊗-intro f (⊗-intro f' f'') ∘g ⊗-assoc⁻
+  ⊗-assoc⁻⊗-intro = refl
+
+  opaque
+    unfolding ε ⊗-unit-l⁻
+    ⊗-unit-l⁻⊗-intro :
+      ∀ {f : g ⊢ h}
+      → ⊗-unit-l⁻ ∘g f
+      ≡ (⊗-intro id f) ∘g ⊗-unit-l⁻
+    ⊗-unit-l⁻⊗-intro = refl
+
+    ⊗-unit-r⁻⊗-intro :
+      ∀ {f : g ⊢ h}
+      → ⊗-unit-r⁻ ∘g f
+      ≡ (⊗-intro f id) ∘g ⊗-unit-r⁻
+    ⊗-unit-r⁻⊗-intro = refl
 
 _,⊗_ = ⊗-intro
 infixr 20 _,⊗_
-
-opaque
-  unfolding ε
-  ⊗-unit-r :
-    g ⊗ ε ⊢ g
-  ⊗-unit-r {g = g} _ (((w' , []') , w≡w'++[]') , p⟨w'⟩ , []'≡[]) =
-    subst g (sym (++-unit-r _)
-            ∙ cong (w' ++_) (sym []'≡[])
-            ∙ sym w≡w'++[]')
-          p⟨w'⟩
-
-  ⊗-unit-r⁻ :
-    g ⊢ g ⊗ ε
-  ⊗-unit-r⁻ _ p =
-    ((_ , []) , (sym (++-unit-r _))) , (p , refl)
-
-  isPropε : ∀ w → isProp (ε w)
-  isPropε w = isSetString _ _
-
-  rectify :
-    ∀ {w w'}{g : Grammar ℓg}
-    → {p : g w}{q : g w'}
-    → {w≡ w≡' : w ≡ w'}
-    → PathP (λ i → g (w≡  i)) p q
-    → PathP (λ i → g (w≡' i)) p q
-  rectify {w = w}{w'}{g = g}{p = p}{q = q} =
-    subst {A = w ≡ w'} (λ w≡ → PathP (λ i → g (w≡ i)) p q)
-      (isSetString _ _ _ _)
-
-  ⊗-unit-rr⁻ :
-    ∀ {g : Grammar ℓg}
-    → ⊗-unit-r⁻ {g = g} ∘g ⊗-unit-r ≡ id
-  ⊗-unit-rr⁻ {g = g} =
-    funExt λ w → funExt λ (((w' , []') , w≡w'++[]') , p⟨w'⟩ , []'≡[]) →
-    let w≡w' = (sym (sym (++-unit-r _)
-            ∙ cong (w' ++_) (sym []'≡[])
-            ∙ sym w≡w'++[]'))
-    in
-    ⊗≡ _ _
-      (≡-× w≡w'
-        (sym []'≡[]))
-      (ΣPathP
-        ( symP (subst-filler g (sym w≡w') p⟨w'⟩)
-        , isProp→PathP (λ _ → isPropε _) refl []'≡[]))
-
-  ⊗-unit-r⁻r : ∀ {g : Grammar ℓg}
-    → ⊗-unit-r {g = g} ∘g ⊗-unit-r⁻ ≡ id
-  ⊗-unit-r⁻r {g = g} = funExt λ w → funExt λ p →
-    let
-      w≡w : w ≡ w
-      w≡w =       (λ i →
-           (hcomp
-            (doubleComp-faces (λ _ → w)
-             (λ i₁ →
-                hcomp (doubleComp-faces (λ _ → w ++ [])
-                  (λ i₂ → ++-unit-r w i₂) i₁)
-                (w ++ []))
-             i)
-            (++-unit-r w (~ i))))
-    in
-    subst (λ w≡w → subst g w≡w p ≡ p) (isSetString _ _ refl w≡w)
-      (substRefl {B = g} p)
-
-  ⊗-unit-l :
-    ε ⊗ g ⊢ g
-  ⊗-unit-l {g = g} _ p =
-    transport
-      (cong g (cong (_++  p .fst .fst .snd)
-        (sym (p .snd .fst)) ∙ sym (p .fst .snd)))
-      (p .snd .snd)
-
-  ⊗-unit-l⁻ :
-    g ⊢ ε ⊗ g
-  ⊗-unit-l⁻ _ p =
-    (([] , _) , refl) , (refl , p)
-
-  ⊗-unit-ll⁻ :
-    ⊗-unit-l⁻ {g = g} ∘g ⊗-unit-l ≡ id
-  ⊗-unit-ll⁻ {g = g} = funExt λ w → funExt λ p⊗ →
-    let
-      w'≡w : p⊗ .fst .fst .snd ≡ w
-      w'≡w =
-        (λ i →
-            (hcomp
-             (doubleComp-faces (λ _ → p⊗ .fst .fst .snd)
-              (λ i₁ → p⊗ .fst .snd (~ i₁)) i)
-             (p⊗ .snd .fst (~ i) ++ p⊗ .fst .fst .snd)))
-      in
-     ⊗≡ _ _
-       (≡-× (sym (p⊗ .snd .fst)) (sym w'≡w))
-       (ΣPathP ((isProp→PathP (λ i → isSetString _ _) _ _) ,
-       symP (subst-filler g w'≡w (p⊗ .snd .snd))))
-
-  ⊗-unit-l⁻l :
-    ⊗-unit-l {g = g} ∘g ⊗-unit-l⁻ ≡ id
-  ⊗-unit-l⁻l {g = g} = funExt λ w → funExt λ p →
-    let w≡w = λ i →
-                 ((λ i₁ →
-                     ⊗-unit-l⁻ {g = g} w p .snd .fst (~ i₁) ++
-                       ⊗-unit-l⁻ {g = g} w p .fst .fst .snd)
-                  ∙ (λ i₁ → ⊗-unit-l⁻ {g = g} w p .fst .snd (~ i₁)))
-                 i
-    in
-    subst (λ w≡w → subst g w≡w p ≡ p)
-      (isSetString _ _ refl w≡w) (substRefl {B = g} p)
-
-  cong-∘g⊗-unit-l⁻ :
-    (e e' : ε ⊗ g ⊢ h) →
-    (e ∘g ⊗-unit-l⁻ ≡ e' ∘g ⊗-unit-l⁻) →
-    e ≡ e'
-  cong-∘g⊗-unit-l⁻ f g ∘g≡ =
-    cong (f ∘g_) (sym ⊗-unit-ll⁻) ∙
-    cong (_∘g ⊗-unit-l) ∘g≡ ∙
-    cong (g ∘g_) (⊗-unit-ll⁻)
-
-  cong-∘g⊗-unit-r⁻ :
-    (e e' : g ⊗ ε ⊢ h) →
-    (e ∘g ⊗-unit-r⁻ ≡ e' ∘g ⊗-unit-r⁻) →
-    e ≡ e'
-  cong-∘g⊗-unit-r⁻ f g ∘g≡ =
-    cong (f ∘g_) (sym ⊗-unit-rr⁻) ∙
-    cong (_∘g ⊗-unit-r) ∘g≡ ∙
-    cong (g ∘g_) (⊗-unit-rr⁻)
-
-  -- TODO this proof seems overly complicated
-  ⊗-unit-r⊗-intro :
-    (f : g ⊢ h) →
-    ⊗-unit-r ∘g ⊗-intro f id ≡ f ∘g ⊗-unit-r
-  ⊗-unit-r⊗-intro f =
-    cong-∘g⊗-unit-r⁻ (⊗-unit-r ∘g ⊗-intro f id) (f ∘g ⊗-unit-r)
-      ((⊗-unit-r ∘g ⊗-intro f id) ∘g ⊗-unit-r⁻
-        ≡⟨ refl ⟩
-        ⊗-unit-r ∘g ⊗-unit-r⁻ ∘g f
-        ≡⟨ ((λ i → ⊗-unit-r⁻r i ∘g f ∘g ⊗-unit-r⁻r (~ i))) ⟩
-      (f ∘g ⊗-unit-r) ∘g ⊗-unit-r⁻
-      ∎)
-      -- (cong (_∘g f) {!sym ⊗-unit-rr⁻!})
-    -- ⊗-unit-r ∘g ⊗-intro f id
-    --   ≡⟨ {!cong-∘g⊗-unit-r!} ⟩
-    -- f ∘g ⊗-unit-r
-    -- ∎
-
-  ⊗-unit-rl⁻ : ⊗-unit-r ∘g ⊗-unit-l⁻ ≡ id
-  ⊗-unit-rl⁻ = funExt λ w → funExt λ p →
-    isSetString w [] ((⊗-unit-r ∘g ⊗-unit-l⁻) w p) (id {g = ε} w p)
-
-⊗-unit-r' :
-  g ⊗ ε ⊢ g
-⊗-unit-r' = ⊗-elim (ε-elim-r id)
-
-⊗-unit-r'⁻ : g ⊢ g ⊗ ε
-⊗-unit-r'⁻ = ⊗-intro' b∘εr ε-intro
-
-⊗-assoc :
-  g ⊗ (h ⊗ k) ⊢ (g ⊗ h) ⊗ k
-⊗-assoc _ p =
-  ((fst p .fst .fst ++ fst (p .snd .snd) .fst .fst ,
-    fst (p .snd .snd) .fst .snd) ,
-    p .fst .snd ∙
-    cong (p .fst .fst .fst ++_) (p .snd .snd .fst .snd) ∙
-    sym
-    (++-assoc
-      (p .fst .fst .fst)
-      (p .snd .snd .fst .fst .fst)
-      (p .snd .snd .fst .fst .snd))) ,
-  ((((fst p .fst .fst , fst (p .snd .snd) .fst .fst) ,
-    refl) ,
-  ((p .snd .fst) , (p .snd .snd .snd .fst))) , (p .snd .snd .snd .snd))
-
-⊗-assoc⁻ :
-  (g ⊗ h) ⊗ k ⊢ g ⊗ (h ⊗ k)
-⊗-assoc⁻ _ p =
-  (((fst (p .snd .fst) .fst .fst) ,
-    (fst (p .snd .fst) .fst .snd ++ fst p .fst .snd)) ,
-    (p .fst .snd ∙
-    cong (_++ p .fst .fst .snd) (p .snd .fst .fst .snd) ∙
-    ++-assoc
-      (p .snd .fst .fst .fst .fst)
-      (p .snd .fst .fst .fst .snd)
-      (p .fst .fst .snd))) ,
-    (p .snd .fst .snd .fst ,
-    ((_ , refl) ,
-    (p .snd .fst .snd .snd ,
-    p .snd .snd)))
-
-⊗-assoc∘⊗-assoc⁻≡id :
- ⊗-assoc {g = g}{h = h}{k = k} ∘g ⊗-assoc⁻ ≡ id
-⊗-assoc∘⊗-assoc⁻≡id = funExt λ w → funExt λ p →
-  ⊗≡ _ _
-    (≡-× (λ i → p .snd .fst .fst .snd (~ i)) refl)
-    (ΣPathP (
-      (⊗PathP
-        (≡-× refl refl)
-        (≡-× refl refl)) ,
-      refl))
-
-⊗-assoc⁻∘⊗-assoc≡id :
- ⊗-assoc⁻ {g = g}{h = h}{k = k} ∘g ⊗-assoc ≡ id
-⊗-assoc⁻∘⊗-assoc≡id = funExt λ w → funExt λ p →
-  ⊗≡ _ _
-    (≡-× refl (sym (p .snd .snd .fst .snd)))
-    (ΣPathP (
-      refl ,
-      (⊗PathP (≡-× refl refl)
-        (ΣPathP (refl , refl)))))
-
-⊗-assoc⁻⊗-intro :
-  ∀ {f : g ⊢ h}{f' : g' ⊢ h'}{f'' : g'' ⊢ h''}
-  → ⊗-assoc⁻ ∘g (⊗-intro (⊗-intro f f') f'')
-  ≡ ⊗-intro f (⊗-intro f' f'') ∘g ⊗-assoc⁻
-⊗-assoc⁻⊗-intro = refl
-
-opaque
-  unfolding ε ⊗-unit-l⁻
-  ⊗-unit-l⁻⊗-intro :
-    ∀ {f : g ⊢ h}
-    → ⊗-unit-l⁻ ∘g f
-    ≡ (⊗-intro id f) ∘g ⊗-unit-l⁻
-  ⊗-unit-l⁻⊗-intro = refl
-
-  ⊗-unit-r⁻⊗-intro :
-    ∀ {f : g ⊢ h}
-    → ⊗-unit-r⁻ ∘g f
-    ≡ (⊗-intro f id) ∘g ⊗-unit-r⁻
-  ⊗-unit-r⁻⊗-intro = refl

--- a/code/cubical/Grammar/Product.agda
+++ b/code/cubical/Grammar/Product.agda
@@ -17,9 +17,12 @@ private
     k : Grammar ℓk
     l : Grammar ℓl
 
+_&'_ : Grammar ℓg → Grammar ℓh → Grammar (ℓ-max ℓg ℓh)
+(g &' h) w = g w × h w
+infixr 5 _&'_
 opaque
   _&_ : Grammar ℓg → Grammar ℓh → Grammar (ℓ-max ℓg ℓh)
-  (g & h) w = g w × h w
+  _&_ = _&'_
 
 infixr 5 _&_
 

--- a/code/cubical/Grammar/String/Base.agda
+++ b/code/cubical/Grammar/String/Base.agda
@@ -36,7 +36,7 @@ string = KL* char
 
 module _ (isFinSetAlphabet : isFinSet ⟨ Alphabet ⟩) where
   opaque
-    unfolding ε literal
+    unfolding ε literal _⊗_
     uniquely-supported-⌈w⌉ : ∀ w w' → ⌈ w ⌉ w' → w ≡ w'
     uniquely-supported-⌈w⌉ [] [] p = refl
     uniquely-supported-⌈w⌉ [] (c' ∷ w') p =
@@ -56,11 +56,11 @@ module _ (isFinSetAlphabet : isFinSet ⟨ Alphabet ⟩) where
         (DiscreteAlphabet isFinSetAlphabet c c')
 
 opaque
-  unfolding ε literal
+  unfolding ε literal _⊗_
   internalize : (w : String) → ⌈ w ⌉ w
   internalize [] = refl
   internalize (c ∷ w) = (([ c ] , w) , refl) , refl , internalize w
 
-⌈w⌉→string : ⌈ w ⌉ ⊢ string
-⌈w⌉→string {[]} = nil
-⌈w⌉→string {c ∷ w} = cons ∘g LinΣ-intro c ,⊗ ⌈w⌉→string {w}
+  ⌈w⌉→string : ⌈ w ⌉ ⊢ string
+  ⌈w⌉→string {[]} = nil
+  ⌈w⌉→string {c ∷ w} = cons ∘g LinΣ-intro c ,⊗ ⌈w⌉→string {w}

--- a/code/cubical/Grammar/String/Properties.agda
+++ b/code/cubical/Grammar/String/Properties.agda
@@ -21,7 +21,7 @@ open import Grammar.Equivalence.Base Alphabet
 open import Term.Base Alphabet
 
 opaque
-  unfolding ε literal
+  unfolding ε literal _⊗_ same-splits
   propParses-string : EXTERNAL.propParses string
   propParses-string [] (nil .[] x) (nil .[] y) =
     cong (nil []) (isSetString _ _ _ _)

--- a/code/cubical/Grammar/Sum.agda
+++ b/code/cubical/Grammar/Sum.agda
@@ -21,9 +21,12 @@ private
     k : Grammar ℓk
     l : Grammar ℓl
 
+_⊕'_ : Grammar ℓg → Grammar ℓh → Grammar (ℓ-max ℓg ℓh)
+(g ⊕' h) w = g w ⊎ h w
+infixr 5 _⊕'_
 opaque
   _⊕_ : Grammar ℓg → Grammar ℓh → Grammar (ℓ-max ℓg ℓh)
-  (g ⊕ h) w = g w ⊎ h w
+  _⊕_ = _⊕'_
 
 infixr 5 _⊕_
 

--- a/code/cubical/NFA/Base.agda
+++ b/code/cubical/NFA/Base.agda
@@ -49,15 +49,12 @@ record NFA : Type (ℓ-suc ℓN) where
   -- The grammar "Parse q" denotes the type of traces in the NFA
   -- from state q to an accepting state
   data Parse : (q : ⟨ Q ⟩) → Grammar ℓN where
-    nil : ∀ {q} → isAcc q .fst .fst → ∀ w →
-      ε w → Parse q w
-    cons : ∀ tr w →
-      Σ[ s ∈ Splitting w ]
-        literal (label tr) (s .fst .fst) ×
-          Parse (dst tr) (s .fst .snd) →
-        Parse (src tr) w
-    ε-cons : ∀ εtr w →
-      Parse (ε-dst εtr) w → Parse (ε-src εtr) w
+    nil : ∀ {q} → isAcc q .fst .fst →
+      ε ⊢ Parse q
+    cons : ∀ tr →
+      literal (label tr) ⊗' Parse (dst tr) ⊢ Parse (src tr)
+    ε-cons : ∀ εtr →
+      Parse (ε-dst εtr) ⊢ Parse (ε-src εtr)
 
   InitParse : Grammar ℓN
   InitParse = Parse init

--- a/code/cubical/NFA/Base.agda
+++ b/code/cubical/NFA/Base.agda
@@ -8,7 +8,9 @@ open import Cubical.Foundations.Isomorphism
 
 open import Cubical.Relation.Nullary.Base
 open import Cubical.Relation.Nullary.DecidablePropositions
+
 open import Cubical.Data.FinSet
+open import Cubical.Data.Sigma
 open import Cubical.Data.List hiding (init)
 
 open import Grammar Alphabet
@@ -47,12 +49,15 @@ record NFA : Type (ℓ-suc ℓN) where
   -- The grammar "Parse q" denotes the type of traces in the NFA
   -- from state q to an accepting state
   data Parse : (q : ⟨ Q ⟩) → Grammar ℓN where
-    nil : ∀ {q} → isAcc q .fst .fst →
-      ε ⊢ Parse q
-    cons : ∀ tr →
-      literal (label tr) ⊗ Parse (dst tr) ⊢ Parse (src tr)
-    ε-cons : ∀ εtr →
-      Parse (ε-dst εtr) ⊢ Parse (ε-src εtr)
+    nil : ∀ {q} → isAcc q .fst .fst → ∀ w →
+      ε w → Parse q w
+    cons : ∀ tr w →
+      Σ[ s ∈ Splitting w ]
+        literal (label tr) (s .fst .fst) ×
+          Parse (dst tr) (s .fst .snd) →
+        Parse (src tr) w
+    ε-cons : ∀ εtr w →
+      Parse (ε-dst εtr) w → Parse (ε-src εtr) w
 
   InitParse : Grammar ℓN
   InitParse = Parse init
@@ -70,12 +75,14 @@ record NFA : Type (ℓ-suc ℓN) where
 
   open Algebra
 
-  initial : Algebra
-  the-ℓs initial _ = ℓN
-  G initial = Parse
-  nil-case initial = nil
-  cons-case initial = cons
-  ε-cons-case initial = ε-cons
+  opaque
+    unfolding _⊗_
+    initial : Algebra
+    the-ℓs initial _ = ℓN
+    G initial = Parse
+    nil-case initial = nil
+    cons-case initial = cons
+    ε-cons-case initial = ε-cons
 
   record AlgebraHom (alg alg' : Algebra) : Typeω where
     field
@@ -92,90 +99,91 @@ record NFA : Type (ℓ-suc ℓN) where
 
   open AlgebraHom
 
-  idAlgebraHom : (alg : Algebra) →
-    AlgebraHom alg alg
-  f (idAlgebraHom alg) q = id
-  on-nil (idAlgebraHom alg) _ = refl
-  on-cons (idAlgebraHom alg) _ = refl
-  on-ε-cons (idAlgebraHom alg) _ = refl
+  opaque
+    unfolding ⊗-intro
+    idAlgebraHom : (alg : Algebra) →
+      AlgebraHom alg alg
+    f (idAlgebraHom alg) q = id
+    on-nil (idAlgebraHom alg) _ = refl
+    on-cons (idAlgebraHom alg) _ = refl
+    on-ε-cons (idAlgebraHom alg) _ = refl
 
-  AlgebraHom-seq : {alg alg' alg'' : Algebra} →
-    AlgebraHom alg alg' → AlgebraHom alg' alg'' →
-    AlgebraHom alg alg''
-  f (AlgebraHom-seq ϕ ψ) q _ x =
-    ψ .f q _ (ϕ .f q _ x)
-  on-nil (AlgebraHom-seq ϕ ψ) qAcc =
-    cong (λ t → t ⋆ ψ .f _) (ϕ .on-nil qAcc) ∙
-    ψ .on-nil qAcc
-  on-cons (AlgebraHom-seq ϕ ψ) tr =
-    cong (λ t → t ⋆ ψ .f (src tr)) (ϕ .on-cons tr) ∙
-    cong (λ t → ⊗-intro id (ϕ .f (dst tr)) ⋆ t) (ψ .on-cons tr)
-  on-ε-cons (AlgebraHom-seq ϕ ψ) εtr =
-    cong (λ t → t ⋆ ψ .f (ε-src εtr)) (ϕ .on-ε-cons εtr) ∙
-    cong (λ t → ϕ .f (ε-dst εtr)⋆ t) (ψ .on-ε-cons εtr)
+    AlgebraHom-seq : {alg alg' alg'' : Algebra} →
+      AlgebraHom alg alg' → AlgebraHom alg' alg'' →
+      AlgebraHom alg alg''
+    f (AlgebraHom-seq ϕ ψ) q _ x =
+      ψ .f q _ (ϕ .f q _ x)
+    on-nil (AlgebraHom-seq ϕ ψ) qAcc =
+      cong (λ t → t ⋆ ψ .f _) (ϕ .on-nil qAcc) ∙
+      ψ .on-nil qAcc
+    on-cons (AlgebraHom-seq ϕ ψ) tr =
+      cong (λ t → t ⋆ ψ .f (src tr)) (ϕ .on-cons tr) ∙
+      cong (λ t → ⊗-intro id (ϕ .f (dst tr)) ⋆ t) (ψ .on-cons tr)
+    on-ε-cons (AlgebraHom-seq ϕ ψ) εtr =
+      cong (λ t → t ⋆ ψ .f (ε-src εtr)) (ϕ .on-ε-cons εtr) ∙
+      cong (λ t → ϕ .f (ε-dst εtr)⋆ t) (ψ .on-ε-cons εtr)
 
   module _
     (the-alg : Algebra)
     where
-    recTrace : ∀ {q} → Parse q ⊢ the-alg .G q
-    recTrace _ (nil qAcc _ pε) = the-alg .nil-case qAcc _ pε
-    recTrace _ (cons tr _ p⊗) =
-      the-alg .cons-case tr _
-        ((p⊗ .fst) , ((p⊗ .snd .fst) , (recTrace _ (p⊗ .snd .snd))))
-    recTrace _ (ε-cons εtr _ p) =
-      the-alg .ε-cons-case εtr _ (recTrace _ p)
+    opaque
+      unfolding _⊗_
+      recTrace : ∀ {q} → Parse q ⊢ the-alg .G q
+      recTrace _ (nil qAcc _ pε) = the-alg .nil-case qAcc _ pε
+      recTrace _ (cons tr _ p⊗) =
+        the-alg .cons-case tr _
+          ((p⊗ .fst) , ((p⊗ .snd .fst) , (recTrace _ (p⊗ .snd .snd))))
+      recTrace _ (ε-cons εtr _ p) =
+        the-alg .ε-cons-case εtr _ (recTrace _ p)
 
     recInit : Parse init ⊢ the-alg .G init
     recInit = recTrace
 
-    ∃AlgebraHom : AlgebraHom initial the-alg
-    f ∃AlgebraHom q = recTrace {q}
-    on-nil ∃AlgebraHom _ = refl
-    on-cons ∃AlgebraHom _ = refl
-    on-ε-cons ∃AlgebraHom _ = refl
+    opaque
+      unfolding recTrace ⊗-intro initial _⊗_
+      ∃AlgebraHom : AlgebraHom initial the-alg
+      f ∃AlgebraHom q = recTrace {q}
+      on-nil ∃AlgebraHom _ = refl
+      on-cons ∃AlgebraHom _ = refl
+      on-ε-cons ∃AlgebraHom _ = refl
 
-    !AlgebraHom-help :
-      (e : AlgebraHom initial the-alg) →
-      (q : Q .fst) →
-      (∀ w p → e .f q w p ≡ recTrace w p)
-    !AlgebraHom-help e q w (nil qAcc .w pε) =
-      cong (λ a → a w pε) (e .on-nil qAcc)
-    !AlgebraHom-help e .(src tr) w (cons tr .w p⊗) =
-      cong (λ a → a w p⊗) (e .on-cons tr) ∙
-      cong (λ a → the-alg .cons-case tr _
-        ((p⊗ .fst) , ((p⊗ .snd .fst) , a)))
-        (!AlgebraHom-help e (dst tr) _
-          (p⊗ .snd .snd))
-    !AlgebraHom-help e .(ε-src εtr) w (ε-cons εtr .w p) =
-      cong (λ a → a w p) (e .on-ε-cons εtr) ∙
-      cong (the-alg .ε-cons-case εtr w)
-        (!AlgebraHom-help e (ε-dst εtr) _ p)
+      !AlgebraHom-help :
+        (e e' : AlgebraHom initial the-alg) →
+        (q : Q .fst) →
+        (∀ w p → e .f q w p ≡ e' .f q w p)
+      !AlgebraHom-help e e' q w (nil qAcc .w pε) =
+        cong (λ a → a w pε) (e .on-nil qAcc) ∙
+        sym (cong (λ a → a w pε) (e' .on-nil qAcc))
+      !AlgebraHom-help e e' .(src tr) w (cons tr .w p⊗) =
+        cong (λ a → a w p⊗) (e .on-cons tr) ∙
+        cong (λ a → the-alg .cons-case tr _
+          ((p⊗ .fst) , ((p⊗ .snd .fst) , a)))
+          (!AlgebraHom-help e e' (dst tr) _
+            (p⊗ .snd .snd)) ∙
+        sym (cong (λ a → a w p⊗) (e' .on-cons tr))
+      !AlgebraHom-help e e' .(ε-src εtr) w (ε-cons εtr .w p) =
+        cong (λ a → a w p) (e .on-ε-cons εtr) ∙
+        cong (the-alg .ε-cons-case εtr w)
+          (!AlgebraHom-help e e' (ε-dst εtr) _ p) ∙
+        sym (cong (λ a → a w p) (e' . on-ε-cons εtr))
 
     !AlgebraHom :
-      (e : AlgebraHom initial the-alg) →
-      (q : Q .fst) →
-      e .f q ≡ recTrace {q}
-    !AlgebraHom e q =
-      funExt (λ w → funExt (λ p → !AlgebraHom-help e q w p))
-
-    -- TODO rename
-    !AlgebraHom' :
       (e e' : AlgebraHom initial the-alg) →
       (q : Q .fst) →
       e .f q ≡ e' .f q
-    !AlgebraHom' e e' q =
-      !AlgebraHom e q ∙
-      sym (!AlgebraHom e' q)
+    !AlgebraHom e e' q =
+      funExt (λ w → funExt (λ p → !AlgebraHom-help e e' q w p))
 
-  initial→initial≡id :
-    (e : AlgebraHom initial initial) →
-    (q : Q .fst) →
-    (e .f q)
-       ≡
-    id
-  initial→initial≡id e q =
-    !AlgebraHom initial e q ∙
-    sym (!AlgebraHom initial (idAlgebraHom initial) q)
+  opaque
+    unfolding idAlgebraHom
+    initial→initial≡id :
+      (e : AlgebraHom initial initial) →
+      (q : Q .fst) →
+      (e .f q)
+        ≡
+      id
+    initial→initial≡id e q =
+      !AlgebraHom initial e (idAlgebraHom initial) q
 
   algebra-η :
     (e : AlgebraHom initial initial) →
@@ -202,12 +210,14 @@ record NFA : Type (ℓ-suc ℓN) where
 
     open PAlgebra
 
-    P-initial : PAlgebra
-    P-initial .the-ℓs = _
-    P-initial .G q = Parse q ⊗ P
-    P-initial .nil-case acc = ⊗-intro (nil acc) id ∘g ⊗-unit-l⁻
-    P-initial .cons-case tr = ⊗-intro (cons tr) id ∘g ⊗-assoc
-    P-initial .ε-cons-case tr = ⊗-intro (ε-cons tr) id
+    opaque
+      unfolding _⊗_
+      P-initial : PAlgebra
+      P-initial .the-ℓs = _
+      P-initial .G q = Parse q ⊗ P
+      P-initial .nil-case acc = ⊗-intro (nil acc) id ∘g ⊗-unit-l⁻
+      P-initial .cons-case tr = ⊗-intro (cons tr) id ∘g ⊗-assoc
+      P-initial .ε-cons-case tr = ⊗-intro (ε-cons tr) id
 
     record PAlgebraHom (alg alg' : PAlgebra) : Typeω where
       field
@@ -223,25 +233,27 @@ record NFA : Type (ℓ-suc ℓN) where
 
     open PAlgebraHom
 
-    P-idAlgebraHom : (alg : PAlgebra) → PAlgebraHom alg alg
-    P-idAlgebraHom alg .f _ = id
-    P-idAlgebraHom alg .on-nil _ = refl
-    P-idAlgebraHom alg .on-cons _ = refl
-    P-idAlgebraHom alg .on-ε-cons _ = refl
+    opaque
+      unfolding _⊗_ ⊗-intro
+      P-idAlgebraHom : (alg : PAlgebra) → PAlgebraHom alg alg
+      P-idAlgebraHom alg .f _ = id
+      P-idAlgebraHom alg .on-nil _ = refl
+      P-idAlgebraHom alg .on-cons _ = refl
+      P-idAlgebraHom alg .on-ε-cons _ = refl
 
-    PAlgebraHom-seq : {alg alg' alg'' : PAlgebra} →
-      PAlgebraHom alg alg' → PAlgebraHom alg' alg'' →
-      PAlgebraHom alg alg''
-    PAlgebraHom-seq ϕ ψ .f q = ψ .f q ∘g ϕ .f q
-    PAlgebraHom-seq ϕ ψ .on-nil qAcc =
-      cong (ψ .f _ ∘g_) (ϕ .on-nil qAcc) ∙
-      ψ .on-nil qAcc
-    PAlgebraHom-seq ϕ ψ .on-cons t =
-      cong (ψ .f (src t) ∘g_) (ϕ .on-cons t) ∙
-      cong (_∘g ⊗-intro id (ϕ .f (dst t))) (ψ .on-cons t)
-    PAlgebraHom-seq ϕ ψ .on-ε-cons t =
-      cong (ψ .f (ε-src t) ∘g_) (ϕ .on-ε-cons t) ∙
-      cong (_∘g ϕ .f (ε-dst t)) (ψ .on-ε-cons t)
+      PAlgebraHom-seq : {alg alg' alg'' : PAlgebra} →
+        PAlgebraHom alg alg' → PAlgebraHom alg' alg'' →
+        PAlgebraHom alg alg''
+      PAlgebraHom-seq ϕ ψ .f q = ψ .f q ∘g ϕ .f q
+      PAlgebraHom-seq ϕ ψ .on-nil qAcc =
+        cong (ψ .f _ ∘g_) (ϕ .on-nil qAcc) ∙
+        ψ .on-nil qAcc
+      PAlgebraHom-seq ϕ ψ .on-cons t =
+        cong (ψ .f (src t) ∘g_) (ϕ .on-cons t) ∙
+        cong (_∘g ⊗-intro id (ϕ .f (dst t))) (ψ .on-cons t)
+      PAlgebraHom-seq ϕ ψ .on-ε-cons t =
+        cong (ψ .f (ε-src t) ∘g_) (ϕ .on-ε-cons t) ∙
+        cong (_∘g ϕ .f (ε-dst t)) (ψ .on-ε-cons t)
 
     module _ (the-p-alg : PAlgebra) where
       underlyingAlg : Algebra
@@ -260,102 +272,104 @@ record NFA : Type (ℓ-suc ℓN) where
       P-recInit : InitParse ⊗ P ⊢ the-p-alg .G init
       P-recInit = P-recTrace
 
-      ∃PAlgebraHom : PAlgebraHom P-initial the-p-alg
-      ∃PAlgebraHom .f q = P-recTrace
-      ∃PAlgebraHom .on-nil qAcc =
-        (λ i → ⟜-app ∘g ⊗-intro (∃AlgebraHom underlyingAlg .on-nil qAcc i) id
-          ∘g ⊗-unit-l⁻) ∙
-        (λ i → ⟜-β (the-p-alg .nil-case qAcc ∘g ⊗-unit-l) i ∘g ⊗-unit-l⁻) ∙
-        (λ i → the-p-alg .nil-case qAcc ∘g ⊗-unit-l⁻l i)
-      ∃PAlgebraHom .on-cons t =
+      opaque
+        unfolding ∃AlgebraHom P-initial
+        ∃PAlgebraHom : PAlgebraHom P-initial the-p-alg
+        ∃PAlgebraHom .f q = P-recTrace
+        ∃PAlgebraHom .on-nil qAcc =
+          (λ i → ⟜-app ∘g ⊗-intro (∃AlgebraHom underlyingAlg .on-nil qAcc i) id
+            ∘g ⊗-unit-l⁻) ∙
+          (λ i → ⟜-β (the-p-alg .nil-case qAcc ∘g ⊗-unit-l) i ∘g ⊗-unit-l⁻) ∙
+          (λ i → the-p-alg .nil-case qAcc ∘g ⊗-unit-l⁻l i)
+        ∃PAlgebraHom .on-cons t =
           (λ i → ⟜-β ((the-p-alg .cons-case t) ∘g
             ⊗-intro id ⟜-app ∘g ⊗-assoc⁻) i ∘g
             ⊗-intro (⊗-intro id (recTrace underlyingAlg)) id ∘g ⊗-assoc) ∙
-          (λ i → the-p-alg .cons-case t ∘g ⊗-intro id P-recTrace ∘g
-            ⊗-assoc⁻∘⊗-assoc≡id i)
-      ∃PAlgebraHom .on-ε-cons t =
-        (λ i → ⟜-β ((the-p-alg .ε-cons-case t) ∘g ⟜-app) i ∘g
-          ⊗-intro (recTrace underlyingAlg) id)
+            (λ i → the-p-alg .cons-case t ∘g ⊗-intro id P-recTrace ∘g
+              ⊗-assoc⁻∘⊗-assoc≡id i)
+        ∃PAlgebraHom .on-ε-cons t =
+          (λ i → ⟜-β ((the-p-alg .ε-cons-case t) ∘g ⟜-app) i ∘g
+            ⊗-intro (recTrace underlyingAlg) id)
 
-      curryPAlg :
-        PAlgebraHom P-initial the-p-alg → AlgebraHom initial underlyingAlg
-      curryPAlg e .f q = ⟜-intro (e .f q)
-      curryPAlg e .on-nil acc =
-        isoFunInjective (invIso ⟜UMP) _ _
-          ((λ i → ⟜-β (e .f _) i ∘g ⊗-intro (nil acc) id)
-          ∙ (λ i → e .f _ ∘g ⊗-intro (nil acc) id ∘g ⊗-unit-ll⁻ (~ i))
-          ∙ (λ i → e .on-nil acc i ∘g ⊗-unit-l)
-          ∙ sym (⟜-β (the-p-alg .nil-case acc ∘g ⊗-unit-l))
-          )
-      curryPAlg e .on-cons t = isoFunInjective (invIso ⟜UMP) _ _
-        ( ((λ i → ⟜-β (e .f _) i ∘g ⊗-intro (cons t) id))
-        ∙ (λ i → e .f (src t) ∘g
-             ⊗-intro (cons t) id ∘g ⊗-assoc∘⊗-assoc⁻≡id (~ i))
-        ∙ (λ i → e .on-cons t i ∘g ⊗-assoc⁻)
-        ∙ (λ i → the-p-alg .cons-case t ∘g
-             ⊗-intro id (⟜-β (e .f (dst t)) (~ i)) ∘g ⊗-assoc⁻)
-        ∙ (λ i → ⟜-β (the-p-alg .cons-case t ∘g
-                        ⊗-intro id ⟜-app ∘g ⊗-assoc⁻) (~ i) ∘g
-                  ⊗-intro (⊗-intro id (⟜-intro (e .f (dst t)))) id))
-      curryPAlg e .on-ε-cons t = isoFunInjective (invIso ⟜UMP) _ _
-        ((((λ i → ⟜-β (e .f _) i ∘g ⊗-intro (ε-cons t) id)))
-        ∙ e .on-ε-cons t
-        ∙ (λ i → the-p-alg .ε-cons-case t ∘g ⟜-β (e .f (ε-dst t)) (~ i))
-        ∙ (λ i → ⟜-β (the-p-alg .ε-cons-case t ∘g ⟜-app) (~ i) ∘g
-                        ⊗-intro (⟜-intro (e .f (ε-dst t))) id))
+        curryPAlg :
+          PAlgebraHom P-initial the-p-alg → AlgebraHom initial underlyingAlg
+        curryPAlg e .f q = ⟜-intro (e .f q)
+        curryPAlg e .on-nil acc =
+          isoFunInjective (invIso ⟜UMP) _ _
+            ((λ i → ⟜-β (e .f _) i ∘g ⊗-intro (nil acc) id)
+            ∙ (λ i → e .f _ ∘g ⊗-intro (nil acc) id ∘g ⊗-unit-ll⁻ (~ i))
+            ∙ (λ i → e .on-nil acc i ∘g ⊗-unit-l)
+            ∙ sym (⟜-β (the-p-alg .nil-case acc ∘g ⊗-unit-l))
+            )
+        curryPAlg e .on-cons t = isoFunInjective (invIso ⟜UMP) _ _
+          ( ((λ i → ⟜-β (e .f _) i ∘g ⊗-intro (cons t) id))
+          ∙ (λ i → e .f (src t) ∘g
+               ⊗-intro (cons t) id ∘g ⊗-assoc∘⊗-assoc⁻≡id (~ i))
+          ∙ (λ i → e .on-cons t i ∘g ⊗-assoc⁻)
+          ∙ (λ i → the-p-alg .cons-case t ∘g
+               ⊗-intro id (⟜-β (e .f (dst t)) (~ i)) ∘g ⊗-assoc⁻)
+          ∙ (λ i → ⟜-β (the-p-alg .cons-case t ∘g
+                          ⊗-intro id ⟜-app ∘g ⊗-assoc⁻) (~ i) ∘g
+                    ⊗-intro (⊗-intro id (⟜-intro (e .f (dst t)))) id))
+        curryPAlg e .on-ε-cons t = isoFunInjective (invIso ⟜UMP) _ _
+          ((((λ i → ⟜-β (e .f _) i ∘g ⊗-intro (ε-cons t) id)))
+          ∙ e .on-ε-cons t
+          ∙ (λ i → the-p-alg .ε-cons-case t ∘g ⟜-β (e .f (ε-dst t)) (~ i))
+          ∙ (λ i → ⟜-β (the-p-alg .ε-cons-case t ∘g ⟜-app) (~ i) ∘g
+                          ⊗-intro (⟜-intro (e .f (ε-dst t))) id))
 
-      !PAlgebraHom' :
-        (e e' : PAlgebraHom P-initial the-p-alg) →
-        (q : Q .fst) →
-        e .f q ≡ e' .f q
-      !PAlgebraHom' e e' q =
-        isoFunInjective ⟜UMP _ _ (!AlgebraHom' underlyingAlg
-          (curryPAlg e)
-          (curryPAlg e')
-          q)
+        !PAlgebraHom' :
+          (e e' : PAlgebraHom P-initial the-p-alg) →
+          (q : Q .fst) →
+          e .f q ≡ e' .f q
+        !PAlgebraHom' e e' q =
+          isoFunInjective ⟜UMP _ _ (!AlgebraHom underlyingAlg
+            (curryPAlg e)
+            (curryPAlg e')
+            q)
 
-      -- Need to contort things a bit to convince Agda we're terminating
-      PrT-helper :
-        ∀ {q}{wl} →
-        Parse q wl →
-        ∀ {w}{wr} → (w ≡ wl ++ wr) → P wr → the-p-alg .G q w
-      PrT-helper (nil acc _ wl≡[]) splits p =
-        (the-p-alg .nil-case acc ∘g ⊗-unit-l)
-          _ ((_ , splits) , (wl≡[] , p))
-      PrT-helper {wl = wl}
-        (cons tr _ (split' , lit , parse)) {w = w}{wr = wr} splits p =
-        the-p-alg .cons-case tr _ ((_ , pf) ,
-          (lit , (PrT-helper parse refl p)))
-        where
-          pf = splits ∙ cong (_++ wr) (split' .snd) ∙
-            ++-assoc (split' .fst .fst) _ wr
-      PrT-helper (ε-cons εtr _ parse) splits p =
-        the-p-alg .ε-cons-case εtr _ (PrT-helper parse splits p)
+        -- Need to contort things a bit to convince Agda we're terminating
+        PrT-helper :
+          ∀ {q}{wl} →
+          Parse q wl →
+          ∀ {w}{wr} → (w ≡ wl ++ wr) → P wr → the-p-alg .G q w
+        PrT-helper (nil acc _ wl≡[]) splits p =
+          (the-p-alg .nil-case acc ∘g ⊗-unit-l)
+            _ ((_ , splits) , (wl≡[] , p))
+        PrT-helper {wl = wl}
+          (cons tr _ (split' , lit , parse)) {w = w}{wr = wr} splits p =
+          the-p-alg .cons-case tr _ ((_ , pf) ,
+            (lit , (PrT-helper parse refl p)))
+          where
+            pf : w ≡ split' .fst .fst ++ split' .fst .snd ++ wr
+            pf = splits ∙ cong (_++ wr) (split' .snd) ∙
+              ++-assoc (split' .fst .fst) _ wr
+        PrT-helper (ε-cons εtr _ parse) splits p =
+          the-p-alg .ε-cons-case εtr _ (PrT-helper parse splits p)
 
-      -- A direct definition that doesn't use function types
+        -- A direct definition that doesn't use function types
+        -- defining equations (all hold by refl)
+        P-recTrace' : ∀ {q} → Parse q ⊗ P ⊢ the-p-alg .G q
+        P-recTrace' w (splitting , parse , p) =
+          PrT-helper parse (splitting .snd) p
 
-      -- defining equations (all hold by refl)
-      P-recTrace' : ∀ {q} → Parse q ⊗ P ⊢ the-p-alg .G q
-      P-recTrace' w (splitting , parse , p) =
-        PrT-helper parse (splitting .snd) p
+        -- P-recTrace'-nil-test :
+        --   ∀ {q}{acc : ⟨ isAcc q .fst ⟩ } →
+        --   P-recTrace' ∘g ⊗-intro (nil acc) id
+        --   ≡ the-p-alg .nil-case acc ∘g ⊗-unit-l
+        -- P-recTrace'-nil-test = refl
 
-      P-recTrace'-nil-test :
-        ∀ {q}{acc : ⟨ isAcc q .fst ⟩ } →
-        P-recTrace' ∘g ⊗-intro (nil acc) id
-        ≡ the-p-alg .nil-case acc ∘g ⊗-unit-l
-      P-recTrace'-nil-test = refl
+        -- P-recTrace'-cons-test :
+        --   ∀ {tr : ⟨ transition ⟩ } →
+        --   P-recTrace' ∘g ⊗-intro (cons tr) id
+        --   ≡ the-p-alg .cons-case tr ∘g ⊗-intro id P-recTrace' ∘g ⊗-assoc⁻
+        -- P-recTrace'-cons-test = refl
 
-      P-recTrace'-cons-test :
-        ∀ {tr : ⟨ transition ⟩ } →
-        P-recTrace' ∘g ⊗-intro (cons tr) id
-        ≡ the-p-alg .cons-case tr ∘g ⊗-intro id P-recTrace' ∘g ⊗-assoc⁻
-      P-recTrace'-cons-test = refl
-
-      P-recTrace'-ε-cons-test :
-        ∀ {εtr : ⟨ ε-transition ⟩} →
-        P-recTrace' ∘g (⊗-intro (ε-cons εtr) id)
-        ≡ the-p-alg .ε-cons-case εtr ∘g P-recTrace'
-      P-recTrace'-ε-cons-test = refl
+        -- P-recTrace'-ε-cons-test :
+        --   ∀ {εtr : ⟨ ε-transition ⟩} →
+        --   P-recTrace' ∘g (⊗-intro (ε-cons εtr) id)
+        --   ≡ the-p-alg .ε-cons-case εtr ∘g P-recTrace'
+        -- P-recTrace'-ε-cons-test = refl
 
       -- Agda can't figure out this definition is terminating unfortunately
       -- P-recTrace' w ((([]' , w'), splits) , nil acc ._ []'≡[] , p) =
@@ -383,20 +397,22 @@ record NFA : Type (ℓ-suc ℓN) where
       P-recInit' : InitParse ⊗ P ⊢ the-p-alg .G init
       P-recInit' = P-recTrace'
 
-      ∃PAlgebraHom' : PAlgebraHom P-initial the-p-alg
-      ∃PAlgebraHom' .f = λ q → P-recTrace'
-      -- would be refl with an equiv defn of PAlgebraHom
-      ∃PAlgebraHom' .on-nil qAcc =
-        λ i → the-p-alg .nil-case qAcc ∘g (⊗-unit-l⁻l i)
-      -- these would be refl if we changed the definition of PAlgebraHom to pu
-      ∃PAlgebraHom' .on-cons tr =
-        λ i → the-p-alg .cons-case tr ∘g
-          ⊗-intro id P-recTrace' ∘g ⊗-assoc⁻∘⊗-assoc≡id i
-      ∃PAlgebraHom' .on-ε-cons εtrans = refl
+      opaque
+        unfolding P-recTrace'
+        ∃PAlgebraHom' : PAlgebraHom P-initial the-p-alg
+        ∃PAlgebraHom' .f = λ q → P-recTrace'
+        -- would be refl with an equiv defn of PAlgebraHom
+        ∃PAlgebraHom' .on-nil qAcc =
+          λ i → the-p-alg .nil-case qAcc ∘g (⊗-unit-l⁻l i)
+        -- these would be refl if we changed the definition of PAlgebraHom to pu
+        ∃PAlgebraHom' .on-cons tr =
+          λ i → the-p-alg .cons-case tr ∘g
+            ⊗-intro id P-recTrace' ∘g ⊗-assoc⁻∘⊗-assoc≡id i
+        ∃PAlgebraHom' .on-ε-cons εtrans = refl
 
-      -- This justifies that adding P-recTrace' is a
-      -- conservative extension of our type theory
-      P-recTrace'-conservative-extension :
-        ∀ {q} → P-recTrace {q = q} ≡ P-recTrace' {q = q}
-      P-recTrace'-conservative-extension =
-        !PAlgebraHom' ∃PAlgebraHom ∃PAlgebraHom' _
+        -- This justifies that adding P-recTrace' is a
+        -- conservative extension of our type theory
+        P-recTrace'-conservative-extension :
+          ∀ {q} → P-recTrace {q = q} ≡ P-recTrace' {q = q}
+        P-recTrace'-conservative-extension =
+          !PAlgebraHom' ∃PAlgebraHom ∃PAlgebraHom' _

--- a/code/cubical/NFA/Regex/Combinators.agda
+++ b/code/cubical/NFA/Regex/Combinators.agda
@@ -604,7 +604,7 @@ module _ (N : NFA {ℓN}) where
     *-strong-equivalence = mkStrEq
       (recInit *NFA *Alg)
       (foldKL*r (InitParse N) the-KL*-alg)
-      (!*r-AlgebraHom' (InitParse N) (*r-initial (InitParse N))
+      (!*r-AlgebraHom (InitParse N) (*r-initial (InitParse N))
         (record { f = recInit *NFA *Alg ∘g foldKL*r (InitParse N) the-KL*-alg
                 ; on-nil = refl
                 ; on-cons = (λ i → KL*.cons ∘g

--- a/code/cubical/NFA/Regex/Combinators.agda
+++ b/code/cubical/NFA/Regex/Combinators.agda
@@ -89,32 +89,34 @@ module _ (c : ⟨ Alphabet ⟩) where
   literalNFA .label _ = c
   literalNFA .ε-transition = Empty.⊥ , isFinSet⊥
 
-  litNFA-strong-equiv : StrongEquivalence (InitParse literalNFA) (literal c)
-  litNFA-strong-equiv = mkStrEq
-    (recInit _ litAlg)
-    the-inv
-    ⊗-unit-r⁻r
-    (algebra-η _ (AlgebraHom-seq _ (∃AlgebraHom _ litAlg) (record
-      { f = λ { c-st → the-inv ; ε-st → nil Eq.refl }
-      ; on-nil = λ { Eq.refl → refl }
-      ; on-cons = λ _ → λ i →
-        cons _
-        ∘g (⊗-intro id (nil Eq.refl))
-        ∘g ⊗-unit-rr⁻ i
-      ; on-ε-cons = Empty.elim })))
-    where
-      the-inv : literal c ⊢ InitParse literalNFA
-      the-inv =
-        cons _
-        ∘g ⊗-intro id (nil Eq.refl)
-        ∘g ⊗-unit-r⁻
+  opaque
+    unfolding AlgebraHom-seq ∃AlgebraHom
+    litNFA-strong-equiv : StrongEquivalence (InitParse literalNFA) (literal c)
+    litNFA-strong-equiv = mkStrEq
+      (recInit _ litAlg)
+      the-inv
+      ⊗-unit-r⁻r
+      (algebra-η _ (AlgebraHom-seq _ (∃AlgebraHom _ litAlg) (record
+        { f = λ { c-st → the-inv ; ε-st → nil Eq.refl }
+        ; on-nil = λ { Eq.refl → refl }
+        ; on-cons = λ _ → λ i →
+          cons _
+          ∘g (⊗-intro id (nil Eq.refl))
+          ∘g ⊗-unit-rr⁻ i
+        ; on-ε-cons = Empty.elim })))
+      where
+        the-inv : literal c ⊢ InitParse literalNFA
+        the-inv =
+          cons _
+          ∘g ⊗-intro id (nil Eq.refl)
+          ∘g ⊗-unit-r⁻
 
-      litAlg : Algebra literalNFA
-      litAlg .the-ℓs _ = ℓ-zero
-      litAlg .G c-st = literal c
-      litAlg .G ε-st = ε
-      litAlg .nil-case Eq.refl = id
-      litAlg .cons-case _ = ⊗-unit-r
+        litAlg : Algebra literalNFA
+        litAlg .the-ℓs _ = ℓ-zero
+        litAlg .G c-st = literal c
+        litAlg .G ε-st = ε
+        litAlg .nil-case Eq.refl = id
+        litAlg .cons-case _ = ⊗-unit-r
 
 -- Nullary Disjunction
 module _ where
@@ -125,21 +127,23 @@ module _ where
   ⊥NFA .transition = Empty.⊥ , isFinSet⊥
   ⊥NFA .ε-transition = Empty.⊥ , isFinSet⊥
 
-  emptyNFA-strong-equiv :
-    StrongEquivalence (InitParse ⊥NFA) ⊥
-  emptyNFA-strong-equiv = mkStrEq
-    (recInit _ ⊥Alg)
-    ⊥-elim
-    (⊥-η _ _)
-    (algebra-η _ (AlgebraHom-seq _ (∃AlgebraHom _ ⊥Alg)
-      (record { f = λ _ → ⊥-elim
-              ; on-nil = Empty.elim
-              ; on-cons = Empty.elim
-              ; on-ε-cons = Empty.elim })))
-    where
-      ⊥Alg : Algebra ⊥NFA
-      ⊥Alg .the-ℓs = _
-      ⊥Alg .G _ = ⊥
+  opaque
+    unfolding AlgebraHom-seq ∃AlgebraHom
+    emptyNFA-strong-equiv :
+      StrongEquivalence (InitParse ⊥NFA) ⊥
+    emptyNFA-strong-equiv = mkStrEq
+      (recInit _ ⊥Alg)
+      ⊥-elim
+      (⊥-η _ _)
+      (algebra-η _ (AlgebraHom-seq _ (∃AlgebraHom _ ⊥Alg)
+        (record { f = λ _ → ⊥-elim
+                ; on-nil = Empty.elim
+                ; on-cons = Empty.elim
+                ; on-ε-cons = Empty.elim })))
+      where
+        ⊥Alg : Algebra ⊥NFA
+        ⊥Alg .the-ℓs = _
+        ⊥Alg .G _ = ⊥
 
 -- Binary Disjunction
 -- Given two NFAs N and N', accepts a string if and only if
@@ -215,7 +219,7 @@ module _ (N : NFA {ℓN}) (N' : NFA {ℓN'}) where
     }
 
   opaque
-    unfolding _⊕_ ⊕-inr ⊕-inl
+    unfolding _⊕_ ⊕-inr ⊕-inl AlgebraHom-seq ∃AlgebraHom
     ⊕-strong-equivalence :
       StrongEquivalence (InitParse ⊕NFA) (InitParse N ⊕ InitParse N')
     ⊕-strong-equivalence = mkStrEq
@@ -300,22 +304,24 @@ module _ where
   εNFA .transition = Empty.⊥ , isFinSet⊥
   εNFA .ε-transition = Empty.⊥ , isFinSet⊥
 
-  εNFA-strong-equiv :
-    StrongEquivalence (InitParse εNFA) ε
-  εNFA-strong-equiv = mkStrEq
-    (recInit _ εAlg)
-    (nil _)
-    refl
-    (algebra-η _ (AlgebraHom-seq _ (∃AlgebraHom _ εAlg) (record
-      { f = λ _ → nil _
-      ; on-nil = λ _ → refl
-      ; on-cons = Empty.elim
-      ; on-ε-cons = Empty.elim })))
-    where
-      εAlg : Algebra εNFA
-      εAlg .the-ℓs = _
-      εAlg .G = λ _ → ε
-      εAlg .nil-case = λ _ → id
+  opaque
+    unfolding AlgebraHom-seq ∃AlgebraHom
+    εNFA-strong-equiv :
+      StrongEquivalence (InitParse εNFA) ε
+    εNFA-strong-equiv = mkStrEq
+      (recInit _ εAlg)
+      (nil _)
+      refl
+      (algebra-η _ (AlgebraHom-seq _ (∃AlgebraHom _ εAlg) (record
+        { f = λ _ → nil _
+        ; on-nil = λ _ → refl
+        ; on-cons = Empty.elim
+        ; on-ε-cons = Empty.elim })))
+      where
+        εAlg : Algebra εNFA
+        εAlg .the-ℓs = _
+        εAlg .G = λ _ → ε
+        εAlg .nil-case = λ _ → id
 
 -- Concatenation
 -- Given two NFAs N and N', accepts a string w if and only if
@@ -376,177 +382,179 @@ module _ (N : NFA {ℓN}) (N' : NFA {ℓN'}) where
                   ; (N-ε-trans t) → inl (N .ε-dst t)
                   ; (N'-ε-trans t') → inr (N' .ε-dst t') }
 
-  ⊗-strong-equivalence :
-    StrongEquivalence (InitParse ⊗NFA) (InitParse N ⊗ InitParse N')
-  ⊗-strong-equivalence = mkStrEq
-    (recInit _ ⊗Alg)
-    (P-recInit _ _ NPAlg)
-    (!PAlgebraHom' _ _ NPAlg' Prec (P-idAlgebraHom _ _ _) _)
-    (algebra-η ⊗NFA (AlgebraHom-seq _ (∃AlgebraHom _ ⊗Alg) ⊗Alg→initial))
-    where
-      ⊗Alg : Algebra ⊗NFA
-      ⊗Alg .the-ℓs (inl q) = _
-      ⊗Alg .the-ℓs (inr q') = _
-      ⊗Alg .G (inl q) = Parse N q ⊗ InitParse N'
-      ⊗Alg .G (inr q') = Parse N' q'
-      ⊗Alg .nil-case {inr q'} acc = nil (lower acc)
-      ⊗Alg .cons-case (inl t) =
-        ⊗-intro (cons t) id
-        ∘g ⊗-assoc
-      ⊗Alg .cons-case (inr t') = cons t'
-      ⊗Alg .ε-cons-case (N-acc q acc) =
-        ⊗-intro (nil acc) id
-        ∘g ⊗-unit-l⁻
-      ⊗Alg .ε-cons-case (N-ε-trans t) =
-        ⊗-intro (ε-cons t) id
-      ⊗Alg .ε-cons-case (N'-ε-trans t') = ε-cons t'
+  opaque
+    unfolding AlgebraHom-seq ∃AlgebraHom recTrace P-initial !PAlgebraHom' P-idAlgebraHom
+    ⊗-strong-equivalence :
+      StrongEquivalence (InitParse ⊗NFA) (InitParse N ⊗ InitParse N')
+    ⊗-strong-equivalence = mkStrEq
+      (recInit _ ⊗Alg)
+      (P-recInit _ _ NPAlg)
+      (!PAlgebraHom' _ _ NPAlg' Prec (P-idAlgebraHom _ _ _) _)
+      (algebra-η ⊗NFA (AlgebraHom-seq _ (∃AlgebraHom _ ⊗Alg) ⊗Alg→initial))
+      where
+        ⊗Alg : Algebra ⊗NFA
+        ⊗Alg .the-ℓs (inl q) = _
+        ⊗Alg .the-ℓs (inr q') = _
+        ⊗Alg .G (inl q) = Parse N q ⊗ InitParse N'
+        ⊗Alg .G (inr q') = Parse N' q'
+        ⊗Alg .nil-case {inr q'} acc = nil (lower acc)
+        ⊗Alg .cons-case (inl t) =
+          ⊗-intro (cons t) id
+          ∘g ⊗-assoc
+        ⊗Alg .cons-case (inr t') = cons t'
+        ⊗Alg .ε-cons-case (N-acc q acc) =
+          ⊗-intro (nil acc) id
+          ∘g ⊗-unit-l⁻
+        ⊗Alg .ε-cons-case (N-ε-trans t) =
+          ⊗-intro (ε-cons t) id
+        ⊗Alg .ε-cons-case (N'-ε-trans t') = ε-cons t'
 
-      N'Alg : Algebra N'
-      N'Alg .the-ℓs = _
-      N'Alg .G q' = Parse ⊗NFA (inr q')
-      N'Alg .nil-case acc' = nil (lift acc')
-      N'Alg .cons-case t' = cons (inr t')
-      N'Alg .ε-cons-case t' = ε-cons (N'-ε-trans t')
+        N'Alg : Algebra N'
+        N'Alg .the-ℓs = _
+        N'Alg .G q' = Parse ⊗NFA (inr q')
+        N'Alg .nil-case acc' = nil (lift acc')
+        N'Alg .cons-case t' = cons (inr t')
+        N'Alg .ε-cons-case t' = ε-cons (N'-ε-trans t')
 
-      NPAlg : PAlgebra N (InitParse N')
-      NPAlg .the-ℓs = _
-      NPAlg .G q = Parse ⊗NFA (inl q)
-      NPAlg .nil-case acc = ε-cons (N-acc _ acc) ∘g recInit _ N'Alg
-      NPAlg .cons-case t = cons (inl t)
-      NPAlg .ε-cons-case t = ε-cons (N-ε-trans t)
+        NPAlg : PAlgebra N (InitParse N')
+        NPAlg .the-ℓs = _
+        NPAlg .G q = Parse ⊗NFA (inl q)
+        NPAlg .nil-case acc = ε-cons (N-acc _ acc) ∘g recInit _ N'Alg
+        NPAlg .cons-case t = cons (inl t)
+        NPAlg .ε-cons-case t = ε-cons (N-ε-trans t)
 
-      NPAlg' : PAlgebra N (InitParse N')
-      NPAlg' .the-ℓs = _
-      NPAlg' .G q = Parse N q ⊗ InitParse N'
-      NPAlg' .nil-case acc = ⊗-intro (nil acc) id ∘g ⊗-unit-l⁻
-      NPAlg' .cons-case t = ⊗-intro (cons t) id ∘g ⊗-assoc
-      NPAlg' .ε-cons-case t = ⊗-intro (ε-cons t) id
+        NPAlg' : PAlgebra N (InitParse N')
+        NPAlg' .the-ℓs = _
+        NPAlg' .G q = Parse N q ⊗ InitParse N'
+        NPAlg' .nil-case acc = ⊗-intro (nil acc) id ∘g ⊗-unit-l⁻
+        NPAlg' .cons-case t = ⊗-intro (cons t) id ∘g ⊗-assoc
+        NPAlg' .ε-cons-case t = ⊗-intro (ε-cons t) id
 
-      N'≅⊗NFA⟨inr⟩ : recTrace _ ⊗Alg ∘g recInit _ N'Alg ≡ id
-      N'≅⊗NFA⟨inr⟩ =
-        algebra-η N' (AlgebraHom-seq _ (∃AlgebraHom _ N'Alg) (record
-          { f = λ q → recTrace _ ⊗Alg
-          ; on-nil = λ _ → refl
-          ; on-cons = λ _ → refl
-          ; on-ε-cons = λ _ → refl }))
+        N'≅⊗NFA⟨inr⟩ : recTrace _ ⊗Alg ∘g recInit _ N'Alg ≡ id
+        N'≅⊗NFA⟨inr⟩ =
+          algebra-η N' (AlgebraHom-seq _ (∃AlgebraHom _ N'Alg) (record
+            { f = λ q → recTrace _ ⊗Alg
+            ; on-nil = λ _ → refl
+            ; on-cons = λ _ → refl
+            ; on-ε-cons = λ _ → refl }))
 
-      ⊗Alg→initial : AlgebraHom ⊗NFA ⊗Alg (initial ⊗NFA)
-      ⊗Alg→initial .f (inl q) = P-recTrace _ _ NPAlg
-      ⊗Alg→initial .f (inr q') = recTrace _ N'Alg
-      ⊗Alg→initial .on-nil {inr q'} _ = refl
-      ⊗Alg→initial .on-cons (inl t) =
-         (λ i → ⟜-β ((cons (inl t) ∘g ⊗-intro id ⟜-app ∘g ⊗-assoc⁻)) i ∘g
-           ⊗-intro (⊗-intro id (recTrace _ (underlyingAlg _ _ NPAlg))) id ∘g
-             ⊗-assoc) ∙
-          (λ i → cons (inl t) ∘g ⊗-intro id (P-recTrace _ _ NPAlg) ∘g
-            ⊗-assoc⁻∘⊗-assoc≡id i)
-      ⊗Alg→initial .on-cons (inr t) = refl
-      ⊗Alg→initial .on-ε-cons (N-acc _ acc) =
-        ((λ i →
-           ⟜-β (ε-cons (N-acc _ acc) ∘g
-             recInit _ N'Alg ∘g
-               ⊗-unit-l) i ∘g
+        ⊗Alg→initial : AlgebraHom ⊗NFA ⊗Alg (initial ⊗NFA)
+        ⊗Alg→initial .f (inl q) = P-recTrace _ _ NPAlg
+        ⊗Alg→initial .f (inr q') = recTrace _ N'Alg
+        ⊗Alg→initial .on-nil {inr q'} _ = refl
+        ⊗Alg→initial .on-cons (inl t) =
+           (λ i → ⟜-β ((cons (inl t) ∘g ⊗-intro id ⟜-app ∘g ⊗-assoc⁻)) i ∘g
+             ⊗-intro (⊗-intro id (recTrace _ (underlyingAlg _ _ NPAlg))) id ∘g
+               ⊗-assoc) ∙
+            (λ i → cons (inl t) ∘g ⊗-intro id (P-recTrace _ _ NPAlg) ∘g
+              ⊗-assoc⁻∘⊗-assoc≡id i)
+        ⊗Alg→initial .on-cons (inr t) = refl
+        ⊗Alg→initial .on-ε-cons (N-acc _ acc) =
+          ((λ i →
+             ⟜-β (ε-cons (N-acc _ acc) ∘g
+               recInit _ N'Alg ∘g
+                 ⊗-unit-l) i ∘g
+                 ⊗-unit-l⁻) ∙
+          (λ i → ε-cons (N-acc _ acc) ∘g
+          recInit _ N'Alg ∘g ⊗-unit-l⁻l i))
+        ⊗Alg→initial .on-ε-cons (N-ε-trans t) =
+          (λ i → ⟜-β (ε-cons (N-ε-trans t) ∘g ⟜-app) i ∘g
+             ⊗-intro (recTrace _ (underlyingAlg _ _ NPAlg)) id)
+        ⊗Alg→initial .on-ε-cons (N'-ε-trans t') = refl
+
+        Prec : PAlgebraHom _ _ (P-initial N (InitParse N')) NPAlg'
+        Prec .f q =
+          recTrace ⊗NFA ⊗Alg ∘g
+          P-recTrace _ _ NPAlg
+        Prec .on-nil qAcc =
+          (λ i → recTrace _ ⊗Alg ∘g (⟜-β
+              ((ε-cons (N-acc _ qAcc) ∘g recInit _ N'Alg) ∘g ⊗-unit-l) i) ∘g
                ⊗-unit-l⁻) ∙
-        (λ i → ε-cons (N-acc _ acc) ∘g
-        recInit _ N'Alg ∘g ⊗-unit-l⁻l i))
-      ⊗Alg→initial .on-ε-cons (N-ε-trans t) =
-        (λ i → ⟜-β (ε-cons (N-ε-trans t) ∘g ⟜-app) i ∘g
-           ⊗-intro (recTrace _ (underlyingAlg _ _ NPAlg)) id)
-      ⊗Alg→initial .on-ε-cons (N'-ε-trans t') = refl
+          (λ i → recTrace _ ⊗Alg ∘g
+            ε-cons (N-acc _ qAcc) ∘g recInit _ N'Alg ∘g ⊗-unit-l⁻l i) ∙
+          (λ i → ⊗-intro (nil qAcc) id ∘g ⊗-unit-l⁻ ∘g N'≅⊗NFA⟨inr⟩ i)
+        Prec .on-cons t =
+          (λ i → recTrace _ ⊗Alg ∘g
+            ⊗Alg→initial .on-cons (inl t) i)
+        Prec .on-ε-cons t =
+          (λ i → recTrace _ ⊗Alg ∘g
+            ⊗Alg→initial .on-ε-cons (N-ε-trans t) i)
 
-      Prec : PAlgebraHom _ _ (P-initial N (InitParse N')) NPAlg'
-      Prec .f q =
-        recTrace ⊗NFA ⊗Alg ∘g
-        P-recTrace _ _ NPAlg
-      Prec .on-nil qAcc =
-        (λ i → recTrace _ ⊗Alg ∘g (⟜-β
-            ((ε-cons (N-acc _ qAcc) ∘g recInit _ N'Alg) ∘g ⊗-unit-l) i) ∘g
-             ⊗-unit-l⁻) ∙
-        (λ i → recTrace _ ⊗Alg ∘g
-          ε-cons (N-acc _ qAcc) ∘g recInit _ N'Alg ∘g ⊗-unit-l⁻l i) ∙
-        (λ i → ⊗-intro (nil qAcc) id ∘g ⊗-unit-l⁻ ∘g N'≅⊗NFA⟨inr⟩ i)
-      Prec .on-cons t =
-        (λ i → recTrace _ ⊗Alg ∘g
-          ⊗Alg→initial .on-cons (inl t) i)
-      Prec .on-ε-cons t =
-        (λ i → recTrace _ ⊗Alg ∘g
-          ⊗Alg→initial .on-ε-cons (N-ε-trans t) i)
+    ⊗-strong-equivalence' :
+      StrongEquivalence (InitParse ⊗NFA) (InitParse N ⊗ InitParse N')
+    ⊗-strong-equivalence' = mkStrEq
+      (recInit _ ⊗Alg)
+      (P-recInit' _ _ NPAlg)
+      (!PAlgebraHom' _ _ NPAlg' Prec (P-idAlgebraHom _ _ _) _)
+      (algebra-η ⊗NFA (AlgebraHom-seq _ (∃AlgebraHom _ ⊗Alg) ⊗Alg→initial))
+      where
+        ⊗Alg : Algebra ⊗NFA
+        ⊗Alg .the-ℓs (inl q) = _
+        ⊗Alg .the-ℓs (inr q') = _
+        ⊗Alg .G (inl q) = Parse N q ⊗ InitParse N'
+        ⊗Alg .G (inr q') = Parse N' q'
+        ⊗Alg .nil-case {inr q'} acc = nil (lower acc)
+        ⊗Alg .cons-case (inl t) =
+          ⊗-intro (cons t) id
+          ∘g ⊗-assoc
+        ⊗Alg .cons-case (inr t') = cons t'
+        ⊗Alg .ε-cons-case (N-acc q acc) =
+          ⊗-intro (nil acc) id
+          ∘g ⊗-unit-l⁻
+        ⊗Alg .ε-cons-case (N-ε-trans t) =
+          ⊗-intro (ε-cons t) id
+        ⊗Alg .ε-cons-case (N'-ε-trans t') = ε-cons t'
 
-  ⊗-strong-equivalence' :
-    StrongEquivalence (InitParse ⊗NFA) (InitParse N ⊗ InitParse N')
-  ⊗-strong-equivalence' = mkStrEq
-    (recInit _ ⊗Alg)
-    (P-recInit' _ _ NPAlg)
-    (!PAlgebraHom' _ _ NPAlg' Prec (P-idAlgebraHom _ _ _) _)
-    (algebra-η ⊗NFA (AlgebraHom-seq _ (∃AlgebraHom _ ⊗Alg) ⊗Alg→initial))
-    where
-      ⊗Alg : Algebra ⊗NFA
-      ⊗Alg .the-ℓs (inl q) = _
-      ⊗Alg .the-ℓs (inr q') = _
-      ⊗Alg .G (inl q) = Parse N q ⊗ InitParse N'
-      ⊗Alg .G (inr q') = Parse N' q'
-      ⊗Alg .nil-case {inr q'} acc = nil (lower acc)
-      ⊗Alg .cons-case (inl t) =
-        ⊗-intro (cons t) id
-        ∘g ⊗-assoc
-      ⊗Alg .cons-case (inr t') = cons t'
-      ⊗Alg .ε-cons-case (N-acc q acc) =
-        ⊗-intro (nil acc) id
-        ∘g ⊗-unit-l⁻
-      ⊗Alg .ε-cons-case (N-ε-trans t) =
-        ⊗-intro (ε-cons t) id
-      ⊗Alg .ε-cons-case (N'-ε-trans t') = ε-cons t'
+        N'Alg : Algebra N'
+        N'Alg .the-ℓs = _
+        N'Alg .G q' = Parse ⊗NFA (inr q')
+        N'Alg .nil-case acc' = nil (lift acc')
+        N'Alg .cons-case t' = cons (inr t')
+        N'Alg .ε-cons-case t' = ε-cons (N'-ε-trans t')
 
-      N'Alg : Algebra N'
-      N'Alg .the-ℓs = _
-      N'Alg .G q' = Parse ⊗NFA (inr q')
-      N'Alg .nil-case acc' = nil (lift acc')
-      N'Alg .cons-case t' = cons (inr t')
-      N'Alg .ε-cons-case t' = ε-cons (N'-ε-trans t')
+        NPAlg : PAlgebra N (InitParse N')
+        NPAlg .the-ℓs = _
+        NPAlg .G q = Parse ⊗NFA (inl q)
+        NPAlg .nil-case acc = ε-cons (N-acc _ acc) ∘g recInit _ N'Alg
+        NPAlg .cons-case t = cons (inl t)
+        NPAlg .ε-cons-case t = ε-cons (N-ε-trans t)
 
-      NPAlg : PAlgebra N (InitParse N')
-      NPAlg .the-ℓs = _
-      NPAlg .G q = Parse ⊗NFA (inl q)
-      NPAlg .nil-case acc = ε-cons (N-acc _ acc) ∘g recInit _ N'Alg
-      NPAlg .cons-case t = cons (inl t)
-      NPAlg .ε-cons-case t = ε-cons (N-ε-trans t)
+        NPAlg' : PAlgebra N (InitParse N')
+        NPAlg' .the-ℓs = _
+        NPAlg' .G q = Parse N q ⊗ InitParse N'
+        NPAlg' .nil-case acc = ⊗-intro (nil acc) id ∘g ⊗-unit-l⁻
+        NPAlg' .cons-case t = ⊗-intro (cons t) id ∘g ⊗-assoc
+        NPAlg' .ε-cons-case t = ⊗-intro (ε-cons t) id
+        N'≅⊗NFA⟨inr⟩ : recTrace _ ⊗Alg ∘g recInit _ N'Alg ≡ id
+        N'≅⊗NFA⟨inr⟩ =
+          algebra-η N' (AlgebraHom-seq _ (∃AlgebraHom _ N'Alg) (record
+            { f = λ q → recTrace _ ⊗Alg
+            ; on-nil = λ _ → refl
+            ; on-cons = λ _ → refl
+            ; on-ε-cons = λ _ → refl }))
+        ⊗Alg→initial : AlgebraHom ⊗NFA ⊗Alg (initial ⊗NFA)
+        ⊗Alg→initial .f (inl q) = P-recTrace' _ _ NPAlg
+        ⊗Alg→initial .f (inr q') = recTrace _ N'Alg
+        ⊗Alg→initial .on-nil {inr q'} _ = refl
+        ⊗Alg→initial .on-cons (inl t) =
+          λ i → cons (inl t) ∘g ⊗-intro id (P-recTrace' _ _ NPAlg) ∘g
+            ⊗-assoc⁻∘⊗-assoc≡id i
+        ⊗Alg→initial .on-cons (inr t) = refl
+        ⊗Alg→initial .on-ε-cons (N-acc q x) =
+          λ i → ε-cons (N-acc q x) ∘g recTrace _ N'Alg ∘g ⊗-unit-l⁻l i
+        ⊗Alg→initial .on-ε-cons (N-ε-trans x) = refl
+        ⊗Alg→initial .on-ε-cons (N'-ε-trans x) = refl
 
-      NPAlg' : PAlgebra N (InitParse N')
-      NPAlg' .the-ℓs = _
-      NPAlg' .G q = Parse N q ⊗ InitParse N'
-      NPAlg' .nil-case acc = ⊗-intro (nil acc) id ∘g ⊗-unit-l⁻
-      NPAlg' .cons-case t = ⊗-intro (cons t) id ∘g ⊗-assoc
-      NPAlg' .ε-cons-case t = ⊗-intro (ε-cons t) id
-      N'≅⊗NFA⟨inr⟩ : recTrace _ ⊗Alg ∘g recInit _ N'Alg ≡ id
-      N'≅⊗NFA⟨inr⟩ =
-        algebra-η N' (AlgebraHom-seq _ (∃AlgebraHom _ N'Alg) (record
-          { f = λ q → recTrace _ ⊗Alg
-          ; on-nil = λ _ → refl
-          ; on-cons = λ _ → refl
-          ; on-ε-cons = λ _ → refl }))
-      ⊗Alg→initial : AlgebraHom ⊗NFA ⊗Alg (initial ⊗NFA)
-      ⊗Alg→initial .f (inl q) = P-recTrace' _ _ NPAlg
-      ⊗Alg→initial .f (inr q') = recTrace _ N'Alg
-      ⊗Alg→initial .on-nil {inr q'} _ = refl
-      ⊗Alg→initial .on-cons (inl t) =
-        λ i → cons (inl t) ∘g ⊗-intro id (P-recTrace' _ _ NPAlg) ∘g
-          ⊗-assoc⁻∘⊗-assoc≡id i
-      ⊗Alg→initial .on-cons (inr t) = refl
-      ⊗Alg→initial .on-ε-cons (N-acc q x) =
-        λ i → ε-cons (N-acc q x) ∘g recTrace _ N'Alg ∘g ⊗-unit-l⁻l i
-      ⊗Alg→initial .on-ε-cons (N-ε-trans x) = refl
-      ⊗Alg→initial .on-ε-cons (N'-ε-trans x) = refl
-
-      Prec : PAlgebraHom _ _ (P-initial N (InitParse N')) NPAlg'
-      Prec .f q = recTrace _ ⊗Alg ∘g P-recTrace' _ _ NPAlg
-      Prec .on-nil qAcc =
-        (λ i → recTrace _ ⊗Alg ∘g
-          ε-cons (N-acc _ qAcc) ∘g recInit _ N'Alg ∘g ⊗-unit-l⁻l i) ∙
-        (λ i → ⊗-intro (nil qAcc) id ∘g ⊗-unit-l⁻ ∘g N'≅⊗NFA⟨inr⟩ i)
-      Prec .on-cons t =
-        (λ i → recTrace _ ⊗Alg ∘g ⊗Alg→initial .on-cons (inl t) i)
-      Prec .on-ε-cons t =
-        (λ i → recTrace _ ⊗Alg ∘g ⊗Alg→initial .on-ε-cons (N-ε-trans t) i)
+        Prec : PAlgebraHom _ _ (P-initial N (InitParse N')) NPAlg'
+        Prec .f q = recTrace _ ⊗Alg ∘g P-recTrace' _ _ NPAlg
+        Prec .on-nil qAcc =
+          (λ i → recTrace _ ⊗Alg ∘g
+            ε-cons (N-acc _ qAcc) ∘g recInit _ N'Alg ∘g ⊗-unit-l⁻l i) ∙
+          (λ i → ⊗-intro (nil qAcc) id ∘g ⊗-unit-l⁻ ∘g N'≅⊗NFA⟨inr⟩ i)
+        Prec .on-cons t =
+          (λ i → recTrace _ ⊗Alg ∘g ⊗Alg→initial .on-cons (inl t) i)
+        Prec .on-ε-cons t =
+          (λ i → recTrace _ ⊗Alg ∘g ⊗Alg→initial .on-ε-cons (N-ε-trans t) i)
 
 -- Kleene Star
 module _ (N : NFA {ℓN}) where
@@ -590,7 +598,7 @@ module _ (N : NFA {ℓN}) where
   *NFA .ε-dst (N-internal t) = inr (N .ε-dst t)
 
   opaque
-    unfolding ⊗-unit-l⁻ ⊗-unit-l
+    unfolding ⊗-unit-l⁻ ⊗-unit-l *r-initial KL*r-elim id*r-AlgebraHom AlgebraHom-seq ∃AlgebraHom recTrace P-initial !PAlgebraHom' P-idAlgebraHom
     *-strong-equivalence :
       StrongEquivalence (InitParse *NFA) (KL* (InitParse N))
     *-strong-equivalence = mkStrEq

--- a/code/cubical/PDA/Base.agda
+++ b/code/cubical/PDA/Base.agda
@@ -68,7 +68,7 @@ record PDA : Type (ℓ-suc ℓP) where
     nil : ∀ {q} → isAcc q .fst .fst →
       ε ⊢ Parse q []
     cons : ∀ t s →
-      literal (label t) ⊗ Parse (dst t) (push (to-push t) s)
+      literal (label t) ⊗' Parse (dst t) (push (to-push t) s)
         ⊢
       Parse (src t) (withHead (to-pop t) s)
     ε-cons : ∀ t s →


### PR DESCRIPTION
WIP for making tensor opaque.

We make the definition opaque and propagate that opaqueness throughout the codebase. This changes the type signatures of some things, such as `⊗PathP` and Kleene star, as to not leak the details of `⊗`. The largest ergonomic changes relate to the inductive types, like Kleene star and NFA parses. The signatures of each constructor must be manually unfolded
```
  data KL* : Grammar ℓG
    where
    nil : ∀ w → ε w → KL* w
    cons : ∀ w →
      Σ[ s ∈ Splitting w ]
       g (s .fst .fst) × KL* (s .fst .snd) →
      KL* w
```

The remaining work here seems to be in the Kleene star regex-NFA equivalence