### PR TITLE
Strong Equivalence between Dyck grammar and Traces

### DIFF
--- a/code/cubical/Examples/Indexed/Dyck.agda
+++ b/code/cubical/Examples/Indexed/Dyck.agda
@@ -47,11 +47,11 @@ BALANCED = roll ∘g ⊕ᴰ-in balanced' ∘g liftG ,⊗ liftG ,⊗ liftG ,⊗ l
 
 appendAlg : Algebra DyckTy λ _ → IndDyck ⟜ IndDyck
 appendAlg tt = ⊕ᴰ-elim λ
-  { nil' → ⟜-intro-ε id ∘g lowerG
+  { nil' → ⟜-intro ⊗-unit-l ∘g lowerG
   ; balanced' → ⟜-intro (BALANCED
     ∘g lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ NIL ∘g ⊗-unit-r⁻)
        ,⊗ lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ id)
-    ∘g id ,⊗ id ,⊗ ⊗-assoc⁻ ∘g id ,⊗ ⊗-assoc⁻ ∘g ⊗-assoc⁻)
+    ∘g ⊗-assoc⁻4)
   }
 
 append : IndDyck ⊗ IndDyck ⊢ IndDyck
@@ -59,7 +59,44 @@ append = ⟜-intro⁻ (rec _ appendAlg _)
 
 -- Need this lemma for the retract property below
 append-nil-r : append ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ≡ id
-append-nil-r = {!!}
+append-nil-r = goal where
+  opaque
+    unfolding ⊗-intro ⊗-unit-r⁻ ⊗-assoc⁻
+    pf : (⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻) ∘g appendAlg _
+         ≡ roll ∘g map (DyckTy _) (λ _ → ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻)
+    pf = ⊕ᴰ≡ _ _ (λ
+      { nil' →
+        (⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ∘g ⟜-intro ⊗-unit-l ∘g lowerG)
+          ≡⟨ (λ i → ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻⊗-intro {f = (⟜-intro ⊗-unit-l)} i ∘g lowerG) ⟩
+        (⟜-app ∘g id ,⊗ NIL ∘g ⟜-intro ⊗-unit-l ,⊗ id ∘g ⊗-unit-r⁻ ∘g lowerG)
+          ≡⟨ refl ⟩
+        (⟜-app ∘g (⟜-intro ⊗-unit-l ,⊗ id) ∘g (id ,⊗ NIL) ∘g ⊗-unit-r⁻ ∘g lowerG)
+          ≡⟨ cong (_∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ∘g lowerG) (⟜-β ⊗-unit-l) ⟩
+        (⊗-unit-l ∘g (id ,⊗ NIL) ∘g ⊗-unit-r⁻ ∘g lowerG)
+          ≡⟨ cong (_∘g ⊗-unit-r⁻ ∘g lowerG) (sym (⊗-unit-l⊗-intro NIL)) ⟩
+        (NIL ∘g ⊗-unit-l ∘g ⊗-unit-r⁻ ∘g lowerG)
+          ≡⟨ cong (NIL ∘g_) (cong (_∘g lowerG) ⊗-unit-lr⁻) ⟩
+        NIL ∘g lowerG
+        ∎ 
+      ; balanced' →
+        cong ((⟜-app ∘g id ,⊗ NIL) ∘g_) ⊗-unit-r⁻⊗-intro
+        ∙ cong (_∘g id ,⊗ NIL ∘g ⊗-unit-r⁻) (⟜-β _)
+        ∙ cong ((BALANCED
+                 ∘g id ,⊗ (⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g id ,⊗ NIL)
+                 ∘g lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ id) ∘g_)
+               ⊗-assoc⁻4⊗-unit-r⁻
+      })
+
+  append-nil-r' : ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ∘g rec DyckTy appendAlg _ ≡ id
+  append-nil-r' = ind-id' DyckTy (compHomo DyckTy (initialAlgebra DyckTy) appendAlg (initialAlgebra DyckTy)
+    ((λ _ → ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻) , λ _ → pf)
+    (recHomo DyckTy appendAlg))
+    _
+
+  opaque
+    unfolding ⊗-intro ⊗-unit-r⁻
+    goal : append ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ≡ id
+    goal = append-nil-r'
 
 data TraceTag (b : Bool) (n : ℕ) : Type where
   eof' : b Eq.≡ true → n Eq.≡ zero → TraceTag b n

--- a/code/cubical/Examples/Indexed/Dyck.agda
+++ b/code/cubical/Examples/Indexed/Dyck.agda
@@ -469,37 +469,6 @@ genBuildTrace (suc m) = &ᴰ-intro λ n → ⟜-intro
   ∘g ⊗-assoc⁻3
   )
 
-PileAlg : Algebra DyckTy (λ _ → &[ n ∈ _ ] (GenDyck n ⟜ Trace true n))
-PileAlg _ = ⊕ᴰ-elim (λ
-  { nil' → &ᴰ-intro λ n → ⟜-intro-ε (genMkTree n) ∘g lowerG
-  ; balanced' → &ᴰ-intro λ n → ⟜-intro
-    (genBALANCED n
-     ∘g id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
-     ∘g ⊗-assoc⁻4
-     ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG) ,⊗ id
-     )
-  })
-
-PileAlg' : Algebra DyckTy (λ _ → &[ n ∈ _ ] (GenDyck n & Trace true n ⟜ Trace true n))
-PileAlg' _ = ⊕ᴰ-elim λ
-  { nil' → &ᴰ-intro (λ n → ⟜-intro (&-intro
-    (genMkTree n ∘g ⊗-unit-l ∘g lowerG ,⊗ id)
-    (⊗-unit-l ∘g lowerG ,⊗ id)))
-  ; balanced' → &ᴰ-intro (λ n → ⟜-intro (&-intro
-    ( genBALANCED n
-      ∘g id ,⊗ (&-π₁ ∘g ⟜-app ∘g (&ᴰ-π (suc n)) ,⊗ id)
-      ∘g id ,⊗ id ,⊗ CLOSE
-      ∘g id ,⊗ id ,⊗ id ,⊗ (&-π₂ ∘g ⟜-app ∘g (&ᴰ-π n) ,⊗ id)
-      ∘g lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ id
-      ∘g ⊗-assoc⁻4)
-    ( OPEN
-      ∘g id ,⊗ (&-π₂ ∘g ⟜-app ∘g (&ᴰ-π (suc n)) ,⊗ id)
-      ∘g id ,⊗ id ,⊗ CLOSE
-      ∘g id ,⊗ id ,⊗ id ,⊗ (&-π₂ ∘g ⟜-app ∘g (&ᴰ-π n) ,⊗ id)
-      ∘g lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ id
-      ∘g ⊗-assoc⁻4)))
-  }
-
 {-
 
   genAppend' n (balanced(lp, d₁, rp, d₂)) (genMkTree n t)
@@ -573,7 +542,7 @@ pfAlg _ =
         ; balanced' → &ᴰ≡ _ _ λ n →
           ⟜-intro-natural ∙
           cong ⟜-intro
-            ( (λ i → genMkTree n
+            ((λ i → genMkTree n
               ∘g ⟜-β (OPEN
                 ∘g id ,⊗ (⟜-app ∘g &ᴰ-π (suc n) ,⊗ id)
                 ∘g id ,⊗ id ,⊗ CLOSE
@@ -593,6 +562,7 @@ pfAlg _ =
                 ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
                 ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ (buildTrace ∘g eq-π lhs rhs ∘g lowerG) ,⊗ id)
                 ∘g ⊗-assoc⁻4)
+            -- by inductive hypothesis for the left subtree
             ∙ (λ i → genBALANCED n
                 ∘g id ,⊗ (⟜-app ∘g (&ᴰ-π (suc n) ∘g eq-π-pf lhs rhs i) ,⊗ id)
                 ∘g id ,⊗ id ,⊗ CLOSE
@@ -600,12 +570,36 @@ pfAlg _ =
                 ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ (buildTrace ∘g eq-π lhs rhs ∘g lowerG) ,⊗ id)
                 ∘g ⊗-assoc⁻4)
             ∙ (λ i → genBALANCED n
-                ∘g id ,⊗ (⟜-app ∘g (&ᴰ-π (suc n) ∘g rhs ∘g eq-π lhs rhs) ,⊗ id)
+                ∘g id ,⊗ (⟜-β (⟜-app ∘g id ,⊗ genMkTree (suc n)) i ∘g (&ᴰ-π (suc n) ∘g genAppend') ,⊗ id)
                 ∘g id ,⊗ id ,⊗ CLOSE
                 ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
-                ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ (buildTrace ∘g eq-π lhs rhs ∘g lowerG) ,⊗ id)
+                ∘g (lowerG ,⊗ (eq-π lhs rhs ∘g lowerG) ,⊗ lowerG ,⊗ (buildTrace ∘g eq-π lhs rhs ∘g lowerG) ,⊗ id)
                 ∘g ⊗-assoc⁻4)
-            ∙ {!!})
+            ∙ (λ i → genBALANCED n
+                ∘g id ,⊗ (⟜-app ∘g id ,⊗ (NIL ,⊗ id ∘g ⊗-unit-l⁻))
+                ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-β (genMkTree n ∘g ⟜-app) (~ i) ∘g (&ᴰ-π n ∘g buildTrace ∘g eq-π lhs rhs) ,⊗ id)
+                ∘g (lowerG ,⊗ (upgradeBuilder (suc n) ∘g append' ∘g eq-π lhs rhs ∘g lowerG) ,⊗ lowerG ,⊗ lowerG ,⊗ id)
+                ∘g ⊗-assoc⁻4)
+            -- inductive hypothesis 
+            ∙ ((λ i → genBALANCED n
+                ∘g id ,⊗ (⟜-app ∘g id ,⊗ (NIL ,⊗ id ∘g ⊗-unit-l⁻))
+                ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-app ∘g (&ᴰ-π n ∘g eq-π-pf lhs rhs i) ,⊗ id)
+                ∘g (lowerG ,⊗ (upgradeBuilder (suc n) ∘g append' ∘g eq-π lhs rhs ∘g lowerG) ,⊗ lowerG ,⊗ lowerG ,⊗ id)
+                ∘g ⊗-assoc⁻4))
+            ∙ ((λ i → genBALANCED n
+                ∘g id ,⊗ (⟜-app ∘g id ,⊗ (NIL ,⊗ id ∘g ⊗-unit-l⁻))
+                ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-β (⟜-app ∘g id ,⊗ genMkTree n) i ∘g upgradeBuilder n ,⊗ id)
+                ∘g (lowerG ,⊗ (upgradeBuilder (suc n) ∘g append' ∘g eq-π lhs rhs ∘g lowerG) ,⊗ lowerG ,⊗ (append' ∘g eq-π lhs rhs ∘g lowerG) ,⊗ id)
+                ∘g ⊗-assoc⁻4))
+            ∙ (λ i → genBALANCED n
+                ∘g id ,⊗ (⟜-app ∘g id ,⊗ (NIL ,⊗ id ∘g ⊗-unit-l⁻))
+                ∘g id ,⊗ id ,⊗ id ,⊗ ⟜-app
+                ∘g lowerG ,⊗ (upgradeBuilder (suc n) ∘g lowerG {ℓ-zero}) ,⊗ lowerG ,⊗ ((upgradeBuilder n) ∘g lowerG {ℓ-zero}) ,⊗ genMkTree n
+                ∘g ⊗-assoc⁻4⊗-intro {f = id}{f' = liftG {ℓ-zero} ∘g append' ∘g eq-π lhs rhs ∘g lowerG}{f'' = id}{f''' = liftG {ℓ-zero} ∘g append' ∘g eq-π lhs rhs ∘g lowerG}{f'''' = id} (~ i)
+              )
+            ∙ (λ i →
+              upgradeBalancedBuilder n (genMkTree n) (~ i)
+              ∘g (id ,⊗ (liftG {ℓ-zero} ∘g append' ∘g eq-π lhs rhs ∘g lowerG) ,⊗ id ,⊗ ((liftG {ℓ-zero} ∘g append' ∘g eq-π lhs rhs ∘g lowerG))) ,⊗ id))
           ∙ sym ⟜-intro-natural
         }
 
@@ -627,176 +621,24 @@ genRetr = equalizer-section _ _
         ; balanced' → refl
         }
 
--- genRetr = ind' DyckTy PileAlg
---   (compHomo DyckTy (initialAlgebra DyckTy) buildTraceAlg PileAlg
---     ((λ _ → f2) , (λ _ → f2-is-homo))
---     (recHomo DyckTy buildTraceAlg))
---   (compHomo DyckTy (initialAlgebra DyckTy) appendAlg PileAlg
---     ((λ _ → f1) , λ _ → f1-is-homo)
---     (recHomo DyckTy appendAlg))
---   _
---   where
---     f2 : &[ n ∈ _ ] (Trace true n ⟜ Trace true n) ⊢ &[ n ∈ _ ] (GenDyck n ⟜ Trace true n)
---     f2 = &ᴰ-intro λ n → ⟜-intro (genMkTree n ∘g ⟜-app) ∘g &ᴰ-π n
-
---     f2⟨_⟩ : ∀ n → &[ n ∈ _ ] (Trace true n ⟜ Trace true n) ⊢ GenDyck n ⟜ Trace true n
---     f2⟨ n ⟩ = ⟜-intro (genMkTree n ∘g ⟜-app) ∘g &ᴰ-π n
-
---     opaque
---       unfolding ⊗-intro
---       f2-homo-lem : ∀ n →
---         genMkTree (suc n)
---         ∘g (⟜-app ∘g &ᴰ-π (suc n) ,⊗ id)
---         ∘g (id ,⊗ CLOSE)
---         ∘g id ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
---         ≡
---         (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
---         ∘g f2 ,⊗ id ,⊗ f2 ,⊗ id
---       -- this looks false or at least unproveable, the lhs makes
---       -- recursive calls at (suc n) and n whereas the rhs makes
---       -- recursive calls at 0 and n
---       f2-homo-lem n =
---         {!!}
---         ∙ ((λ i → (⟜-β (genMkTree 0 ∘g ⟜-app) (~ i) ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-β (genMkTree n ∘g ⟜-app) (~ i) ∘g &ᴰ-π n ,⊗ id)))
---         ∙ (λ i → (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻⊗-intro {f = f2}(~ i)) ,⊗ id ,⊗ (⟜-app ∘g (f2⟨ n ⟩) ,⊗ id))
-
---       f2-is-homo : f2 ∘g buildTraceAlg _ ≡ PileAlg _ ∘g map (DyckTy _) (λ _ → f2)
---       f2-is-homo = &ᴰ≡ _ _ λ n →
---         ⊕ᴰ≡ _ _ λ
---           { nil' → cong (_∘g lowerG) (⟜-mapCod-precomp (genMkTree n) ⊗-unit-l)
---           ; balanced' →
---             ⟜-intro-natural
---             ∙ cong ⟜-intro (
---               cong (genMkTree n ∘g_) (⟜-β _)
---               ∙ (λ i → genBALANCED n
---                 ∘g id ,⊗ genMkTree (suc n)
---                 ∘g id ,⊗ (⟜-app ∘g &ᴰ-π (suc n) ,⊗ id)
---                 ∘g id ,⊗ id ,⊗ CLOSE
---                 ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
---                 ∘g ⊗-assoc⁻4
---                 ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG) ,⊗ id)
---               ∙ {!!}
---               ∙ λ i → genBALANCED n
---                 ∘g id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
---                 ∘g ⊗-assoc⁻4⊗-intro {f = id}{f' = f2}{f'' = id}{f''' = f2}{f'''' = id} (~ i)
---                 ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG) ,⊗ id
---               )
---             ∙ sym ⟜-intro-natural
---           -- (λ i →
---           --   ⟜-intro (genMkTree ∘g ⟜-app)
---           --   ∘g ⟜-intro
---           -- ∙ {!!}
---           -- ∙ (λ i → ⟜-intro
---           --   (genBALANCED n
---           --   ∘g id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
---           --   ∘g ⊗-assoc⁻4
---           --   ∘g (lowerG ,⊗ lowerG {ℓ-zero} ,⊗ lowerG ,⊗ lowerG {ℓ-zero}) ,⊗ id)
---           --   ∘g id ,⊗ (liftG ∘g f2 ∘g lowerG) ,⊗ id ,⊗ (liftG ∘g f2 ∘g lowerG))
---           }
---     --   ; balanced' → &ᴰ≡ _ _ λ m →
---     --      (⟜-intro (genMkTree ∘g ⟜-app) ∘g &ᴰ-π m) ∘g
---     --       buildTraceAlg _
---     --      ∘g ⊕ᴰ-in balanced'
---     --       ≡⟨ {!!} ⟩
---     --   &ᴰ-π m ∘g
---     --     (PileAlg _ ∘g
---     --     map (DyckTy _)
---     --     (λ _ → &ᴰ-intro (λ n → ⟜-intro (genMkTree ∘g ⟜-app) ∘g &ᴰ-π n)))
---     --     ∘g ⊕ᴰ-in balanced'
---     --     ∎
---     -- }
-
---     f1 : IndDyck ⟜ IndDyck ⊢ &[ n ∈ _ ] (GenDyck n ⟜ Trace true n)
---     f1 = (&ᴰ-intro λ n → ⟜-intro (⟜-app ∘g id ,⊗ genMkTree n) ∘g &ᴰ-π n) ∘g (&ᴰ-intro upgradeBuilder)
-
---     f1⟨_⟩ : ∀ n → IndDyck ⟜ IndDyck ⊢ GenDyck n ⟜ Trace true n
---     f1⟨_⟩ n = ⟜-intro (⟜-app ∘g id ,⊗ genMkTree n) ∘g upgradeBuilder n
---     opaque
---       unfolding ⊗-intro
-
---       -- focusing on a subterm in the proof below
---       f1-homo-lem : ∀ n →
---         (⟜-app ∘g ⟜-intro (⟜-app ,⊗ id {g = literal RP ⊗ GenDyck n} ∘g ⊗-assoc) ,⊗ (NIL ,⊗ id ∘g ⊗-unit-l⁻))
---         ∘g id ,⊗ id ,⊗ (⟜-app ∘g upgradeBuilder n ,⊗ genMkTree n)
---         ≡
---         ((⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g f1) ,⊗ id ,⊗ (⟜-app ∘g (&ᴰ-π n ∘g f1) ,⊗ id))
---       f1-homo-lem n =
---         (λ i → (⟜-β (⟜-app ,⊗ id ∘g ⊗-assoc) i ∘g id ,⊗ (NIL ,⊗ id ∘g ⊗-unit-l⁻))
---           ∘g id ,⊗ id ,⊗ (⟜-app ∘g upgradeBuilder n ,⊗ genMkTree n))
---         ∙ (λ i →
---              (⟜-app ,⊗ id ∘g ⊗-assoc⊗-intro {f = id}{f' = NIL}{f'' = id} i ∘g id ,⊗ ⊗-unit-l⁻)
---              ∘g id ,⊗ id ,⊗ (⟜-app ∘g upgradeBuilder n ,⊗ genMkTree n))
---         ∙ (λ i → (⟜-app ∘g id ,⊗ NIL) ,⊗ id ∘g ⊗-assoc⊗-unit-l⁻ i ∘g id ,⊗ id ,⊗ (⟜-app ∘g upgradeBuilder n ,⊗ genMkTree n))
---         ∙ (λ i → (⟜-β (⟜-app ∘g id ,⊗ mkTree) (~ i) ∘g upgradeBuilder 0 ,⊗ EOF ∘g ⊗-unit-r⁻)
---                  ,⊗ id
---                  ,⊗ (⟜-β (⟜-app ∘g id ,⊗ genMkTree n) (~ i) ∘g upgradeBuilder n ,⊗ id))
---         ∙ λ i → (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻⊗-intro {f = f1} (~ i)) ,⊗ id ,⊗ (⟜-app ∘g (&ᴰ-π n ∘g f1) ,⊗ id)
-
---       f1-is-homo : f1 ∘g appendAlg _ ≡ PileAlg _ ∘g map (DyckTy _) λ _ → f1
---       f1-is-homo = ⊕ᴰ≡ _ _ λ
---         { nil' → &ᴰ≡ _ _ λ n →
---           ⟜≡ _ _
---               (cong (_∘g ((upgradeBuilder n ∘g ⟜-intro ⊗-unit-l ∘g lowerG) ,⊗ id)) (⟜-β _)
---               ∙ cong (_∘g (lowerG ,⊗ id)) (upgradeNilBuilder n (genMkTree n) ∙ sym (⟜-β _)))
---         ; balanced' → &ᴰ≡ _ _ λ n → ⟜≡ _ _
---           ( cong (_∘g ((upgradeBuilder n ∘g ⟜-intro (BALANCED ∘g lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ id) ∘g ⊗-assoc⁻4)) ,⊗ id)) (⟜-β _)
---           ∙ upgradeBalancedBuilder n (genMkTree n)
---           ∙ (λ i → genBALANCED n ∘g id ,⊗ f1-homo-lem n i ∘g lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ id ∘g ⊗-assoc⁻4)
---           ∙ cong ((genBALANCED n ∘g id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)) ∘g_) (sym (⊗-assoc⁻4⊗-intro {f = lowerG}{f' = f1 ∘g lowerG}{f'' = lowerG}{f''' = f1 ∘g lowerG}{f'''' = id}))
--- {-
---       (genBALANCED n ∘g
---        id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
---        ∘g ⊗-assoc⁻4
---        ∘g (lowerG ,⊗ f1 ∘g lowerG ,⊗ lowerG ,⊗ f1 ∘g lowerG) ,⊗ id)
---  -}
---           ∙ cong (_∘g ((id ,⊗ (liftG {ℓ-zero} ∘g f1 ∘g lowerG) ,⊗ id ,⊗ (liftG {ℓ-zero} ∘g f1 ∘g lowerG))) ,⊗ id) (sym (⟜-β _)))
-
---           --  (⟜-app ∘g (⟜-intro (⟜-app ∘g id ,⊗ genMkTree) ∘g upgradeBuilder n ∘g ⟜-intro (BALANCED ∘g lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ id) ∘g ⊗-assoc⁻4)) ,⊗ id
---           --   ≡⟨ {!!} ⟩
---           --   ⟜-app
---           -- ∘g (⟜-intro (genBALANCED n
---           --             ∘g  id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
---           --             ∘g ⊗-assoc⁻4
---           --             ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG) ,⊗ id)
---           --    ∘g id ,⊗ (liftG {ℓ-zero} ∘g f1 ∘g lowerG) ,⊗ id ,⊗ (liftG {ℓ-zero} ∘g f1 ∘g lowerG))
---           --    ,⊗ id
---           --  ∎)
---           }
-
---       -- ⟜-app ∘g
---       -- (&ᴰ-π n ∘g
---       --  (PileAlg tt ∘g map (DyckTy tt) (λ _ → f1)) ∘g ⊕ᴰ-in balanced')
---       -- ,⊗ id
-
--- -- Dyck≅Trace : StrongEquivalence IndDyck (Trace true 0)
--- -- Dyck≅Trace =
--- --   unambiguousRetract→StrongEquivalence
--- --     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0 ∘g genBuildTrace 0)
--- --     mkTree
--- --     (mkTree ∘g ⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0 ∘g buildTrace
--- --      ≡⟨ (λ i → ⟜-mapCod-postcompε mkTree EOF (~ i) ∘g &ᴰ-π 0 ∘g buildTrace) ⟩
--- --      ⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g ⟜-mapCod mkTree ∘g &ᴰ-π 0 ∘g buildTrace
--- --      ≡⟨ refl ⟩
--- --      ⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0 ∘g (&ᴰ-intro λ n → ⟜-mapCod (genMkTree n) ∘g &ᴰ-π n) ∘g buildTrace
--- --      ≡⟨ cong (((⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g &ᴰ-π 0) ∘g_) genRetr ⟩
--- --      (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g &ᴰ-π 0 ∘g (&ᴰ-intro λ n → ⟜-intro (⟜-app ∘g id ,⊗ genMkTree n) ∘g &ᴰ-π n) ∘g genAppend'
--- --      ≡⟨ refl ⟩
--- --      (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g ⟜-mapDom mkTree ∘g &ᴰ-π 0 ∘g genAppend'
--- --      ≡⟨ refl ⟩
--- --      (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g ⟜-mapDom mkTree ∘g append'
--- --      ≡⟨ ((λ i → ⟜-mapDom-postcompε mkTree EOF i ∘g append')) ⟩
--- --      ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ∘g append'
--- --      ≡⟨ append-nil-r' ⟩
--- --     id ∎)
--- --     isUnambiguousTrace
-
--- -- -- I don't think we actually need to prove the following
--- -- -- GenDyck≅Trace : ∀ n → StrongEquivalence (GenDyck n) (Trace true n)
--- -- -- GenDyck≅Trace n =
--- -- --   unambiguousRetract→StrongEquivalence
--- -- --     (transportG (cong (Trace true) (+-zero n))
--- -- --       ∘g ⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0
--- -- --       ∘g genBuildTrace n)
--- -- --     genMkTree
--- -- --     {!!}
--- -- --     isUnambiguousTrace
+Dyck≅Trace : StrongEquivalence IndDyck (Trace true 0)
+Dyck≅Trace =
+  unambiguousRetract→StrongEquivalence
+    (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0 ∘g genBuildTrace 0)
+    mkTree
+    (mkTree ∘g ⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0 ∘g buildTrace
+     ≡⟨ (λ i → ⟜-mapCod-postcompε mkTree EOF (~ i) ∘g &ᴰ-π 0 ∘g buildTrace) ⟩
+     ⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g ⟜-mapCod mkTree ∘g &ᴰ-π 0 ∘g buildTrace
+     ≡⟨ refl ⟩
+     ⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0 ∘g (&ᴰ-intro λ n → ⟜-mapCod (genMkTree n) ∘g &ᴰ-π n) ∘g buildTrace
+     ≡⟨ cong (((⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g &ᴰ-π 0) ∘g_) genRetr ⟩
+     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g &ᴰ-π 0 ∘g (&ᴰ-intro λ n → ⟜-intro (⟜-app ∘g id ,⊗ genMkTree n) ∘g &ᴰ-π n) ∘g genAppend'
+     ≡⟨ refl ⟩
+     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g ⟜-mapDom mkTree ∘g &ᴰ-π 0 ∘g genAppend'
+     ≡⟨ refl ⟩
+     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g ⟜-mapDom mkTree ∘g append'
+     ≡⟨ ((λ i → ⟜-mapDom-postcompε mkTree EOF i ∘g append')) ⟩
+     ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ∘g append'
+     ≡⟨ append-nil-r' ⟩
+    id ∎)
+    isUnambiguousTrace

--- a/code/cubical/Examples/Indexed/Dyck.agda
+++ b/code/cubical/Examples/Indexed/Dyck.agda
@@ -344,34 +344,71 @@ genRetr :
 genRetr = ind' DyckTy PileAlg
   (compHomo DyckTy (initialAlgebra DyckTy) buildTraceAlg PileAlg
     ((λ _ → &ᴰ-intro λ n → ⟜-intro (genMkTree ∘g ⟜-app) ∘g &ᴰ-π n) , λ _ → ⊕ᴰ≡ _ _ λ
-      { nil' → {!refl!}
-      ; balanced' → {!refl!} })
+      { nil' → &ᴰ≡ _ _ (λ m →
+          cong (_∘g lowerG) (⟜-mapCod-precomp genMkTree ⊗-unit-l)
+        )
+      ; balanced' → &ᴰ≡ _ _ λ m →
+         (⟜-intro (genMkTree ∘g ⟜-app) ∘g &ᴰ-π m) ∘g
+          buildTraceAlg _
+         ∘g ⊕ᴰ-in balanced'
+          ≡⟨ {!!} ⟩
+      &ᴰ-π m ∘g
+        (PileAlg _ ∘g
+        map (DyckTy _)
+        (λ _ → &ᴰ-intro (λ n → ⟜-intro (genMkTree ∘g ⟜-app) ∘g &ᴰ-π n)))
+        ∘g ⊕ᴰ-in balanced'
+        ∎
+    })
     (recHomo DyckTy buildTraceAlg))
   (compHomo DyckTy (initialAlgebra DyckTy) appendAlg PileAlg
     ((λ _ → (&ᴰ-intro λ n → ⟜-intro (⟜-app ∘g id ,⊗ genMkTree) ∘g &ᴰ-π n) ∘g (&ᴰ-intro upgradeBuilder)) , λ _ → ⊕ᴰ≡ _ _ (λ
-    { nil' → {!refl!}
+    { nil' → &ᴰ≡ _ _ λ {
+        zero →
+       ⟜-intro (⟜-app ∘g id ,⊗ genMkTree) ∘g
+       ⟜-intro ⊗-unit-l ∘g lowerG
+        ≡⟨ (λ i → ⟜-mapDom-precomp genMkTree ⊗-unit-l i ∘g lowerG) ⟩
+       ⟜-intro (⊗-unit-l ∘g id ,⊗ genMkTree) ∘g
+       lowerG
+        ≡⟨ ((λ i → ⟜-intro (⊗-unit-l⊗-intro genMkTree (~ i)) ∘g lowerG)) ⟩
+      ⟜-intro (genMkTree ∘g ⊗-unit-l) ∘g
+      lowerG
+      ∎
+      ; (suc m) →
+       ⟜-intro (⟜-app ∘g id ,⊗ genMkTree) ∘g
+       ⟜-intro (⟜2⊗ (⟜2-intro-ε ⟜-app)) ∘g
+       ⟜-intro ⊗-unit-l ∘g lowerG
+        ≡⟨ (λ i → ⟜-mapDom-precomp genMkTree (⟜2⊗ (⟜2-intro-ε ⟜-app)) i ∘g
+                  ⟜-intro ⊗-unit-l ∘g lowerG) ⟩
+      ⟜-intro (⟜2⊗ (⟜2-intro-ε ⟜-app) ∘g id ,⊗ genMkTree) ∘g
+      ⟜-intro ⊗-unit-l ∘g lowerG
+        ≡⟨ {!!} ⟩
+      ⟜-intro (genMkTree ∘g ⊗-unit-l) ∘g
+      lowerG
+      ∎
+     }
     ; balanced' → {!refl!} }))
     (recHomo DyckTy appendAlg))
   _
 
 Dyck≅Trace : StrongEquivalence IndDyck (Trace true 0)
-Dyck≅Trace = 
+Dyck≅Trace =
   unambiguousRetract→StrongEquivalence
     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0 ∘g genBuildTrace 0)
     genMkTree
-    (genMkTree ∘g
-      ⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0 ∘g buildTrace
-     ≡⟨ {!!} ⟩
-     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g &ᴰ-π 0 ∘g (&ᴰ-intro λ n → ⟜-intro (genMkTree ∘g ⟜-app) ∘g &ᴰ-π n) ∘g buildTrace
+    (genMkTree ∘g ⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0 ∘g buildTrace
+     -- TODO ⟜-mapCod-postcompε needs to be proven in LinearFunction.agda
+     ≡⟨ (λ i → ⟜-mapCod-postcompε (genMkTree {n = 0}) EOF (~ i) ∘g &ᴰ-π 0 ∘g buildTrace) ⟩
+     ⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g ⟜-mapCod genMkTree ∘g &ᴰ-π 0 ∘g buildTrace
+     ≡⟨ refl ⟩
+     ⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0 ∘g (&ᴰ-intro λ n → ⟜-mapCod genMkTree ∘g &ᴰ-π n) ∘g buildTrace
      ≡⟨ cong (((⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g &ᴰ-π 0) ∘g_) genRetr ⟩
      (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g &ᴰ-π 0 ∘g (&ᴰ-intro λ n → ⟜-intro (⟜-app ∘g id ,⊗ genMkTree {n = n}) ∘g &ᴰ-π n) ∘g genAppend'
-     ≡⟨ {!!} ⟩
-     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g ⟜-intro (⟜-app ∘g id ,⊗ mkTree) ∘g &ᴰ-π 0 ∘g genAppend'
      ≡⟨ refl ⟩
-     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g ⟜-intro (⟜-app ∘g id ,⊗ mkTree) ∘g append'
+     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g ⟜-mapDom mkTree ∘g &ᴰ-π 0 ∘g genAppend'
      ≡⟨ refl ⟩
-     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g ⟜-intro (⟜-app ∘g id ,⊗ mkTree) ∘g append'
-     ≡⟨ {!!} ⟩
+     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g ⟜-mapDom mkTree ∘g append'
+     -- TODO ⟜-mapDom-postcompε also needs to be proven
+     ≡⟨ ((λ i → ⟜-mapDom-postcompε mkTree EOF i ∘g append')) ⟩
      ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ∘g append'
      ≡⟨ append-nil-r' ⟩
     id ∎)

--- a/code/cubical/Examples/Indexed/Dyck.agda
+++ b/code/cubical/Examples/Indexed/Dyck.agda
@@ -264,7 +264,6 @@ opaque
   --       (upgradeBuilder n ∘g ⟜-intro {!!}) ,⊗ id
   --       ≡ (f ∘g {!!})
   -- uB-lem' = {!!}
-
   upgradeNilBuilder :
     ∀ n (f : Trace true n ⊢ GenDyck n)
        → (⟜-app ∘g id ,⊗ f) ∘g
@@ -480,9 +479,29 @@ genRetr = ind' DyckTy PileAlg
   where
     f1 : IndDyck ⟜ IndDyck ⊢ &[ n ∈ _ ] (GenDyck n ⟜ Trace true n)
     f1 = (&ᴰ-intro λ n → ⟜-intro (⟜-app ∘g id ,⊗ genMkTree) ∘g &ᴰ-π n) ∘g (&ᴰ-intro upgradeBuilder)
+
+    f1⟨_⟩ : ∀ n → IndDyck ⟜ IndDyck ⊢ GenDyck n ⟜ Trace true n
+    f1⟨_⟩ n = ⟜-intro (⟜-app ∘g id ,⊗ genMkTree) ∘g upgradeBuilder n
     opaque
       unfolding ⊗-intro
-        
+
+      -- focusing on a subterm in the proof below
+      f1-homo-lem : ∀ n →
+        (⟜-app ∘g ⟜-intro (⟜-app ,⊗ id {g = literal RP ⊗ GenDyck n} ∘g ⊗-assoc) ,⊗ (NIL ,⊗ id ∘g ⊗-unit-l⁻))
+        ∘g id ,⊗ id ,⊗ (⟜-app ∘g upgradeBuilder n ,⊗ genMkTree)
+        ≡
+        ((⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g f1) ,⊗ id ,⊗ (⟜-app ∘g (&ᴰ-π n ∘g f1) ,⊗ id))
+      f1-homo-lem n =
+        (λ i → (⟜-β (⟜-app ,⊗ id ∘g ⊗-assoc) i ∘g id ,⊗ (NIL ,⊗ id ∘g ⊗-unit-l⁻))
+          ∘g id ,⊗ id ,⊗ (⟜-app ∘g upgradeBuilder n ,⊗ genMkTree))
+        ∙ (λ i →
+             (⟜-app ,⊗ id ∘g ⊗-assoc⊗-intro {f = id}{f' = NIL}{f'' = id} i ∘g id ,⊗ ⊗-unit-l⁻)
+             ∘g id ,⊗ id ,⊗ (⟜-app ∘g upgradeBuilder n ,⊗ genMkTree))
+        ∙ (λ i → (⟜-app ∘g id ,⊗ NIL) ,⊗ id ∘g ⊗-assoc⊗-unit-l⁻ i ∘g id ,⊗ id ,⊗ (⟜-app ∘g upgradeBuilder n ,⊗ genMkTree))
+        ∙ (λ i → (⟜-β (⟜-app ∘g id ,⊗ genMkTree) (~ i) ∘g upgradeBuilder 0 ,⊗ EOF ∘g ⊗-unit-r⁻)
+                 ,⊗ id
+                 ,⊗ (⟜-β (⟜-app ∘g id ,⊗ genMkTree) (~ i) ∘g upgradeBuilder n ,⊗ id))
+        ∙ λ i → (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻⊗-intro {f = f1} (~ i)) ,⊗ id ,⊗ (⟜-app ∘g (&ᴰ-π n ∘g f1) ,⊗ id)
   
       f1-is-homo : f1 ∘g appendAlg _ ≡ PileAlg _ ∘g map (DyckTy _) λ _ → f1
       f1-is-homo = ⊕ᴰ≡ _ _ λ
@@ -493,7 +512,7 @@ genRetr = ind' DyckTy PileAlg
         ; balanced' → &ᴰ≡ _ _ λ n → ⟜≡ _ _
           ( cong (_∘g ((upgradeBuilder n ∘g ⟜-intro (BALANCED ∘g lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ id) ∘g ⊗-assoc⁻4)) ,⊗ id)) (⟜-β _)
           ∙ upgradeBalancedBuilder n genMkTree
-          ∙ {!!}
+          ∙ (λ i → genBALANCED n ∘g id ,⊗ f1-homo-lem n i ∘g lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ id ∘g ⊗-assoc⁻4)
           ∙ cong ((genBALANCED n ∘g id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)) ∘g_) (sym (⊗-assoc⁻4⊗-intro {f = lowerG}{f' = f1 ∘g lowerG}{f'' = lowerG}{f''' = f1 ∘g lowerG}{f'''' = id}))
 {-
       (genBALANCED n ∘g

--- a/code/cubical/Examples/Indexed/Dyck.agda
+++ b/code/cubical/Examples/Indexed/Dyck.agda
@@ -60,15 +60,18 @@ append' = rec _ appendAlg _
 append : IndDyck ⊗ IndDyck ⊢ IndDyck
 append = ⟜-intro⁻ append'
 
--- Need this lemma for the retract property below
-append-nil-r : append ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ≡ id
-append-nil-r = goal where
-  opaque
-    unfolding ⊗-intro ⊗-unit-r⁻ ⊗-assoc⁻
-    pf : (⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻) ∘g appendAlg _
+append-nil-r' : ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ∘g append' ≡ id
+append-nil-r' = ind-id' DyckTy (compHomo DyckTy (initialAlgebra DyckTy) appendAlg (initialAlgebra DyckTy)
+    ((λ _ → ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻) , λ _ → pf)
+    (recHomo DyckTy appendAlg))
+    _
+  where
+    opaque
+      unfolding ⊗-intro ⊗-unit-r⁻ ⊗-assoc⁻
+      pf : (⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻) ∘g appendAlg _
          ≡ roll ∘g map (DyckTy _) (λ _ → ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻)
-    pf = ⊕ᴰ≡ _ _ (λ
-      { nil' →
+      pf = ⊕ᴰ≡ _ _ (λ
+        { nil' →
         (⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ∘g ⟜-intro ⊗-unit-l ∘g lowerG)
           ≡⟨ (λ i → ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻⊗-intro {f = (⟜-intro ⊗-unit-l)} i ∘g lowerG) ⟩
         (⟜-app ∘g id ,⊗ NIL ∘g ⟜-intro ⊗-unit-l ,⊗ id ∘g ⊗-unit-r⁻ ∘g lowerG)
@@ -81,21 +84,18 @@ append-nil-r = goal where
           ≡⟨ cong (NIL ∘g_) (cong (_∘g lowerG) ⊗-unit-lr⁻) ⟩
         NIL ∘g lowerG
         ∎ 
-      ; balanced' →
+        ; balanced' →
         cong ((⟜-app ∘g id ,⊗ NIL) ∘g_) ⊗-unit-r⁻⊗-intro
         ∙ cong (_∘g id ,⊗ NIL ∘g ⊗-unit-r⁻) (⟜-β _)
         ∙ cong ((BALANCED
                  ∘g id ,⊗ (⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g id ,⊗ NIL)
                  ∘g lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ id) ∘g_)
                ⊗-assoc⁻4⊗-unit-r⁻
-      })
+        })
 
-  append-nil-r' : ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ∘g append' ≡ id
-  append-nil-r' = ind-id' DyckTy (compHomo DyckTy (initialAlgebra DyckTy) appendAlg (initialAlgebra DyckTy)
-    ((λ _ → ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻) , λ _ → pf)
-    (recHomo DyckTy appendAlg))
-    _
-
+-- Need this lemma for the retract property below
+append-nil-r : append ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ≡ id
+append-nil-r = goal where
   opaque
     unfolding ⊗-intro ⊗-unit-r⁻
     goal : append ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ≡ id
@@ -335,20 +335,7 @@ PileAlg _ = ⊕ᴰ-elim (λ
      ∘g ⊗-assoc⁻4
      ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG) ,⊗ id
      )
-    --  ⟜-intro (
-    -- {!?!}
-    --   ∘g id ,⊗ id ,⊗ id ,⊗ ⟜-app
-    --   ∘g ⊗-assoc⁻4
-    --   ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG) ,⊗ id)
-  }) -- ⊕ᴰ-elim (λ
-  -- { nil' → {!!} -- ⟜-intro (⟜-app ∘g id ,⊗ genMkTree) ∘g genAppend' ∘g NIL ∘g lowerG
-  -- ; balanced' → ⟜-intro (
-  --     genBALANCED n 
-  --     ∘g {!!}
-  --     ∘g id ,⊗ id ,⊗ id ,⊗ ⟜-app
-  --     ∘g ⊗-assoc⁻4
-  --     ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG) ,⊗ id)
-  -- })
+  })
 
 genRetr :
   Path (IndDyck ⊢ &[ n ∈ _ ] (GenDyck n ⟜ Trace true n))
@@ -372,7 +359,22 @@ Dyck≅Trace =
   unambiguousRetract→StrongEquivalence
     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0 ∘g genBuildTrace 0)
     genMkTree
-    {!cong (&ᴰ-π 0 ∘g_) genRetr ∙ ?!}
+    (genMkTree ∘g
+      ⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻ ∘g &ᴰ-π 0 ∘g buildTrace
+     ≡⟨ {!!} ⟩
+     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g &ᴰ-π 0 ∘g (&ᴰ-intro λ n → ⟜-intro (genMkTree ∘g ⟜-app) ∘g &ᴰ-π n) ∘g buildTrace
+     ≡⟨ cong (((⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g &ᴰ-π 0) ∘g_) genRetr ⟩
+     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g &ᴰ-π 0 ∘g (&ᴰ-intro λ n → ⟜-intro (⟜-app ∘g id ,⊗ genMkTree {n = n}) ∘g &ᴰ-π n) ∘g genAppend'
+     ≡⟨ {!!} ⟩
+     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g ⟜-intro (⟜-app ∘g id ,⊗ mkTree) ∘g &ᴰ-π 0 ∘g genAppend'
+     ≡⟨ refl ⟩
+     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g ⟜-intro (⟜-app ∘g id ,⊗ mkTree) ∘g append'
+     ≡⟨ refl ⟩
+     (⟜-app ∘g id ,⊗ EOF ∘g ⊗-unit-r⁻) ∘g ⟜-intro (⟜-app ∘g id ,⊗ mkTree) ∘g append'
+     ≡⟨ {!!} ⟩
+     ⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻ ∘g append'
+     ≡⟨ append-nil-r' ⟩
+    id ∎)
     isUnambiguousTrace
 
 -- I don't think we actually need to prove the following
@@ -385,227 +387,3 @@ Dyck≅Trace =
 --     genMkTree
 --     {!!}
 --     isUnambiguousTrace
-
--- -- -- prove this by induction and this should imply the retract property
--- -- genRetract :
--- --   ∀ {n} →
--- --   Path (IndDyck ⊗ Trace n true ⊢ GenIndDyck (n , true))
--- --     (genMkTree ∘g ⟜-app ∘g (&ᴰ-π n ∘g traceBuilder) ,⊗ id)
--- --     (genAppend {n = n} ∘g id ,⊗ genMkTree)
--- -- genRetract = {!!}
-
--- -- genSection :
--- --   ∀ {n} →
--- --   Path (Trace n true ⊢ Trace n true)
--- --     -- seems unavoidable unfortunately
--- --     (subst (λ m → Trace n true ⊢ Trace m true) (+-zero n)
--- --       (⟜-app ∘g ⊸0⊗ EOF ∘g &ᴰ-π 0 ∘g genTraceBuilder {m = n} ∘g genMkTree))
--- --     id
--- -- genSection = {!!}
-
--- -- -- mkTree ∘g ((⟜-app ∘g ⊸0⊗ (roll ∘g ⊕ᴰ-in eof' ∘g ⊕ᴰ-in Eq.refl ∘g ⊕ᴰ-in Eq.refl)) ∘g &ᴰ-π 0)
-
--- -- -- is a homomorphism from eTAlg to (initialAlgebra DyckTy)
-
--- -- Dyck≅Trace : StrongEquivalence IndDyck (Trace zero true)
--- -- Dyck≅Trace = mkStrEq exhibitTrace' mkTree
--- --   {!!} -- use mkTreeAlg
--- --   (ind-id' DyckTy (compHomo DyckTy (initialAlgebra DyckTy) eTAlg (initialAlgebra DyckTy)
--- --     ((λ _ → mkTree ∘g appEOF)
--- --     , λ _ → ⊕ᴰ≡ _ _ (λ
--- --       { nil' →
--- --         cong
--- --           (rec TraceTys mkTreeAlg (0 , true) ∘g_)
--- --           (p (roll ∘g ⊕ᴰ-in eof' ∘g ⊕ᴰ-in Eq.refl ∘g ⊕ᴰ-in Eq.refl))
--- --       ; balanced' →
--- --         mkTree ∘g appEOF ∘g eTAlg _ ∘g ⊕ᴰ-in balanced'
--- --           ≡⟨ refl ⟩
--- --         mkTree ∘g ⟜-app ∘g ⊸0⊗ EOF ∘g ⟜-intro {k = Trace 0 true}
--- --           (OPEN
--- --           ∘g id ,⊗ (⟜-app ∘g &ᴰ-π (suc 0) ,⊗ id)
--- --           ∘g id ,⊗ id ,⊗ CLOSE
--- --           ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ id)
--- --           ∘g id ,⊗ id ,⊗ ⊗-assoc⁻ ∘g id ,⊗ ⊗-assoc⁻ ∘g ⊗-assoc⁻)
--- --           ≡⟨ {!!} ⟩
--- --         mkTree ∘g OPEN
--- --           ∘g id ,⊗ (⟜-app ∘g &ᴰ-π (suc 0) ,⊗ id)
--- --           ∘g id ,⊗ id ,⊗ CLOSE
--- --           ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ id)
--- --           ∘g id ,⊗ id ,⊗ ⊗-assoc⁻ ∘g id ,⊗ ⊗-assoc⁻ ∘g ⊗-assoc⁻
--- --           ∘g ⊸0⊗ EOF
--- --           ≡⟨ refl ⟩
--- --         BALANCED
--- --           ∘g id ,⊗ rec TraceTys mkTreeAlg (1 , true)
--- --           ∘g id ,⊗ (⟜-app ∘g &ᴰ-π (suc 0) ,⊗ id)
--- --           ∘g id ,⊗ id ,⊗ CLOSE
--- --           ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ id)
--- --           ∘g id ,⊗ id ,⊗ ⊗-assoc⁻ ∘g id ,⊗ ⊗-assoc⁻ ∘g ⊗-assoc⁻
--- --           ∘g ⊸0⊗ EOF
--- --           ≡⟨ {!!} ⟩ -- TODO: tedious but just βη
--- --         BALANCED
--- --           ∘g id ,⊗ (rec TraceTys mkTreeAlg (1 , true) ∘g (⟜-app ∘g &ᴰ-π (suc 0) ,⊗ id ∘g id ,⊗ (CLOSE ∘g id ,⊗ appEOF)))
--- --           ≡⟨ (λ i → BALANCED ∘g id ,⊗ the-lemma i) ⟩
--- --         BALANCED
--- --           ∘g id ,⊗ (mkTree ∘g appEOF) ,⊗ id ,⊗ (mkTree ∘g appEOF)
--- --           ∎
--- -- -- ⊸0⊗ : ε ⊢ k → l ⊢ l ⊗ k
--- -- -- ⊸0⊗ f = id ,⊗ f ∘g ⊗-unit-r⁻
-  
--- --         -- rec TraceTys mkTreeAlg (0 , true) ∘g
--- --         -- ⟜-app ∘g
--- --         -- id ,⊗ (roll ∘g
--- --         --     ⊕ᴰ-in eof' ∘g ⊕ᴰ-in Eq.refl ∘g ⊕ᴰ-in Eq.refl) ∘g
--- --         -- ⊗-unit-r⁻ ∘g
--- --         -- ⟜-intro {k = Trace 0 true}
--- --         --   (roll ∘g ⊕ᴰ-in open'
--- --         --   ∘g id ,⊗ ((⟜-app ∘g &ᴰ-π (suc 0) ,⊗ ((roll ∘g ⊕ᴰ-in close' ∘g ⊕ᴰ-in (_ , Eq.refl) ∘g id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ id)) ∘g ⊗-assoc⁻)) ∘g ⊗-assoc⁻)
--- --         --   ∘g ⊗-assoc⁻)
--- --         --   ≡⟨ cong ((rec TraceTys mkTreeAlg (0 , true)) ∘g_) (q' _ _) ⟩
--- --         -- rec TraceTys mkTreeAlg (0 , true) ∘g
--- --         -- roll ∘g
--- --         -- ⊕ᴰ-in open' ∘g
--- --         -- -- Bool.elim {A = λ b → literal [ ⊗ GenIndDyck (suc 0 , b)  ⊢ GenIndDyck (0 , b)}
--- --         -- --   (roll ∘g ⊕ᴰ-in balanced')
--- --         -- --   ⊤-intro true ∘g
--- --         -- id ,⊗
--- --         --   (⟜-app ∘g
--- --         --     &ᴰ-π (suc 0) ,⊗
--- --         --     (roll ∘g
--- --         --       ⊕ᴰ-in close' ∘g
--- --         --       ⊕ᴰ-in (0 , Eq.refl) ∘g id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ id) ∘g
--- --         --       ⊗-assoc⁻) ∘g
--- --         --    ⊗-assoc⁻) ∘g
--- --         -- ⊗-assoc⁻ ∘g
--- --         -- id ,⊗ (roll ∘g ⊕ᴰ-in eof' ∘g ⊕ᴰ-in Eq.refl ∘g ⊕ᴰ-in Eq.refl) ∘g
--- --         -- ⊗-unit-r⁻
--- --         --   ≡⟨ (λ i → roll ∘g ⊕ᴰ-in balanced' ∘g id ,⊗ rec TraceTys mkTreeAlg (1 , true) ∘g ((id ,⊗ (⟜-app ∘g ⊗-intro (&ᴰ-π 1)
--- --         --     (roll ∘g
--- --         --      ⊕ᴰ-in close' ∘g
--- --         --      ⊕ᴰ-in (0 , Eq.refl) ∘g
--- --         --      id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ id) ∘g ⊗-assoc⁻) ∘g ⊗-assoc⁻)
--- --         --     ∘g ⊗-assoc⁻ ∘g id ,⊗ (roll ∘g ⊕ᴰ-in eof' ∘g ⊕ᴰ-in Eq.refl ∘g ⊕ᴰ-in Eq.refl) ∘g (id ,⊗ rec TraceTys mkTreeAlg (1 , true)) ∘g {!!}) ∘g id ,⊗ id ,⊗ {!!}) ∘g (⊗-assoc⁻ ∘g
--- --         --      id ,⊗ (roll ∘g ⊕ᴰ-in eof' ∘g ⊕ᴰ-in Eq.refl ∘g ⊕ᴰ-in Eq.refl) ∘g
--- --         --      ⊗-unit-r⁻)) ⟩
-
-
--- --         -- roll ∘g ⊕ᴰ-in balanced' ∘g id ,⊗ recHomo TraceTys mkTreeAlg .fst (1 , true) ∘g {!!} ∘g (⊗-assoc⁻ ∘g
--- --         --      id ,⊗ (roll ∘g ⊕ᴰ-in eof' ∘g ⊕ᴰ-in Eq.refl ∘g ⊕ᴰ-in Eq.refl) ∘g
--- --         --      ⊗-unit-r⁻)
--- --         -- -- roll ∘g
--- --         -- -- ⊕ᴰ-in balanced' ∘g
--- --         -- -- id ,⊗ ({!id!} ∘g map (DyckTy _) {!!} ∘g {!id!}) ∘g
--- --         -- -- id ,⊗
--- --         -- --   (⟜-app ∘g
--- --         -- --     &ᴰ-π (suc 0) ,⊗
--- --         -- --     (roll ∘g
--- --         -- --       ⊕ᴰ-in close' ∘g
--- --         -- --       ⊕ᴰ-in (0 , Eq.refl) ∘g id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ id) ∘g
--- --         -- --       ⊗-assoc⁻) ∘g
--- --         -- --    ⊗-assoc⁻) ∘g
--- --         -- -- ⊗-assoc⁻ ∘g
--- --         -- -- id ,⊗ (roll ∘g ⊕ᴰ-in eof' ∘g ⊕ᴰ-in Eq.refl ∘g ⊕ᴰ-in Eq.refl) ∘g
--- --         -- -- ⊗-unit-r⁻
--- --         --   ≡⟨ (λ i → roll ∘g ⊕ᴰ-in balanced' ∘g {!!} ) ⟩
--- --         -- roll ∘g
--- --         -- map (DyckTy _)
--- --         --   (λ z →
--- --         --      mkTree ∘g
--- --         --      (⟜-app ∘g
--- --         --       ⊸0⊗
--- --         --       (roll ∘g
--- --         --        ⊕ᴰ-in eof' ∘g ⊕ᴰ-in Eq.refl ∘g ⊕ᴰ-in Eq.refl))
--- --         --      ∘g &ᴰ-π 0)
--- --         --  ∘g ⊕ᴰ-in balanced'
--- --         -- ∎
--- --      }))
--- --     (recHomo DyckTy eTAlg))
--- --     tt)
--- --     where
--- --       -- maybe generalize from 0 to n and prove ∀ n by induction?
--- --       the-lemma :
--- --         Path (TraceAction _ ⊗ literal ] ⊗ TraceAction _ ⊢ IndDyck ⊗ literal ] ⊗ IndDyck)
--- --         (rec TraceTys mkTreeAlg ((suc 0) , true) ∘g (⟜-app ∘g &ᴰ-π (suc 0) ,⊗ id ∘g id ,⊗ (CLOSE ∘g id ,⊗ appEOF)))
--- --         ((rec TraceTys mkTreeAlg (0 , true) ∘g appEOF) ,⊗ id ,⊗ (rec TraceTys mkTreeAlg (0 , true) ∘g appEOF))
--- --       the-lemma = {!!}
-   
--- --       the-lemma' :
--- --         Path (TraceAction _ ⊗ literal ] ⊗ Trace 0 true ⊢ IndDyck ⊗ literal ] ⊗ IndDyck)
--- --         (rec TraceTys mkTreeAlg ((suc 0) , true) ∘g (⟜-app ∘g &ᴰ-π (suc 0) ,⊗ id ∘g id ,⊗ (CLOSE ∘g id ,⊗ id)))
--- --         ((rec TraceTys mkTreeAlg (0 , true) ∘g appEOF) ,⊗ id ,⊗ (rec TraceTys mkTreeAlg (0 , true)))
--- --       the-lemma' = {!!}
--- --       -- TODO rename all of these lemmas and put them in the relevant external
--- --       -- files
--- --       opaque
--- --         unfolding ε
--- --         -- Epsilon.Properties
--- --         u : unambiguous ε
--- --         u = EXTERNAL.propParses→unambiguous isFinBracket λ w → isSetString _ _
-
--- --       -- Epsilon.Properties
--- --       s : ⊗-unit-l {g = ε} ≡ ⊗-unit-r {g = ε}
--- --       s = u _ _
-
--- --       -- Epsilon.Properties
--- --       t : ⊗-unit-l⁻ {g = ε} ≡ ⊗-unit-r⁻ {g = ε}
--- --       t =
--- --         ⊗-unit-l⁻
--- --           ≡⟨ cong (⊗-unit-l⁻ ∘g_) (sym ⊗-unit-r⁻r) ⟩
--- --         ⊗-unit-l⁻ ∘g ⊗-unit-r ∘g ⊗-unit-r⁻
--- --           ≡⟨ cong (λ z → ⊗-unit-l⁻ ∘g z ∘g ⊗-unit-r⁻) (sym s) ⟩
--- --         ⊗-unit-l⁻ ∘g ⊗-unit-l ∘g ⊗-unit-r⁻
--- --           ≡⟨ cong (_∘g ⊗-unit-r⁻) ⊗-unit-ll⁻ ⟩
--- --         ⊗-unit-r⁻
--- --         ∎
-
--- --       opaque
--- --         -- opaque so that ⊗-unit-r⁻ commutes for free
--- --         unfolding ⊗-unit-r⁻ ⊗-unit-l⁻
--- --         q' : ∀ {ℓg ℓh ℓk : Level}
--- --           {g : Grammar ℓg}{h : Grammar ℓh}{k : Grammar ℓk}
--- --           (e : ε ⊢ g)(e' : k ⊗ g ⊢ h) →
--- --           ⟜-app ∘g (id ,⊗ e) ∘g ⊗-unit-r⁻ ∘g ⟜-intro e' ≡
--- --             e' ∘g id ,⊗ e ∘g ⊗-unit-r⁻
--- --         q' e e' = cong (_∘g (id ,⊗ e ∘g ⊗-unit-r⁻)) (⟜-β e')
-
--- --         q : ∀ {ℓg ℓh : Level}
--- --           {g : Grammar ℓg}{h : Grammar ℓh}
--- --           (e : ε ⊢ g)(e' : g ⊢ h) →
--- --           ⟜-app ∘g (id ,⊗ e) ∘g ⊗-unit-r⁻ ∘g ⟜-intro-ε e' ≡ e' ∘g e
--- --         q e e' =
--- --           q' e (e' ∘g ⊗-unit-l) ∙
--- --           cong ((e' ∘g ⊗-unit-l ∘g id ,⊗ e) ∘g_) (sym t)  ∙
--- --           cong (λ z → e' ∘g z ∘g e) ⊗-unit-l⁻l
-
--- --       p : ∀ e →
--- --         ⟜-app ∘g
--- --         (id ,⊗ e) ∘g
--- --         ⊗-unit-r⁻ ∘g
--- --         ⟜-intro-ε id ≡ e
--- --       p e = q e id
-
--- -- weirdAlg : ∀ b → Algebra (TraceBTys b) (λ n → ⊕[ b' ∈ _ ] Trace' b' n)
--- -- weirdAlg b n = ⊕ᴰ-elim (λ
--- --   { eof' →
--- --     ⊕ᴰ-in b
--- --     ∘g ⊕ᴰ-elim (λ { n≡0 → ⊕ᴰ-elim (λ { b≡true →
--- --     roll ∘g ⊕ᴰ-in eof' ∘g ⊕ᴰ-in n≡0 ∘g ⊕ᴰ-in b≡true }) })
--- --   ; open' →
--- --     ⊸-intro⁻ (⊕ᴰ-elim λ b' → ⊸-intro (⊕ᴰ-in b' ∘g roll ∘g ⊕ᴰ-in open'))
--- --   ; close' → ⊕ᴰ-elim λ { n-1 → ⊸-intro⁻ (⊕ᴰ-elim λ b' → ⊸-intro (⊕ᴰ-in b' ∘g roll ∘g ⊕ᴰ-in close' ∘g ⊕ᴰ-in n-1)) }
--- --   ; leftovers' →
--- --     ⊕ᴰ-in b ∘g
--- --     ⊕ᴰ-elim (λ n-1 → ⊕ᴰ-elim (λ { b≡false → roll ∘g ⊕ᴰ-in leftovers' ∘g ⊕ᴰ-in n-1 ∘g ⊕ᴰ-in b≡false }))
--- --   ; unexpected' → ⊕ᴰ-in b ∘g ⊕ᴰ-elim λ n,b≡0,false → roll ∘g ⊕ᴰ-in unexpected' ∘g ⊕ᴰ-in n,b≡0,false
--- --   })
-
--- -- EOF' : ε ⊢ Trace' true 0
--- -- EOF' = roll ∘g ⊕ᴰ-in eof' ∘g ⊕ᴰ-in Eq.refl ∘g ⊕ᴰ-in Eq.refl
-
--- -- OPEN' : ∀ {n b} → literal [ ⊗ Trace' b (suc n) ⊢ Trace' b n
--- -- OPEN' = roll ∘g ⊕ᴰ-in open'
-
--- -- CLOSE' : ∀ {n b} → literal ] ⊗ Trace' b n ⊢ Trace' b (suc n)
--- -- CLOSE' = roll ∘g ⊕ᴰ-in close' ∘g ⊕ᴰ-in (_ , Eq.refl)
-
-
-

--- a/code/cubical/Examples/Indexed/Dyck.agda
+++ b/code/cubical/Examples/Indexed/Dyck.agda
@@ -256,22 +256,78 @@ upgradeBuilder zero = id
 upgradeBuilder (suc n) = ⟜-intro (⟜-app ,⊗ id ∘g ⊗-assoc)
 
 opaque
-  unfolding ⊗-intro
-  uB-lem :
+  unfolding ⊗-intro genBALANCED
+  -- uB-lem' :
+  --   ∀ n (f : Trace true n ⊢ GenDyck n)
+  --       (f' : {!!} ⊢ {!!})
+  --      → (⟜-app ∘g id ,⊗ f) ∘g
+  --       (upgradeBuilder n ∘g ⟜-intro {!!}) ,⊗ id
+  --       ≡ (f ∘g {!!})
+  -- uB-lem' = {!!}
+
+  upgradeNilBuilder :
     ∀ n (f : Trace true n ⊢ GenDyck n)
        → (⟜-app ∘g id ,⊗ f) ∘g
-        (upgradeBuilder n ∘g ⟜-intro ⊗-unit-l ∘g lowerG) ,⊗ id
-        ≡ (f ∘g ⊗-unit-l) ∘g lowerG {ℓ-zero} ,⊗ id
-  uB-lem zero      f =
-    cong (_∘g (lowerG ,⊗ f)) (⟜-β _)
-    ∙ cong (_∘g (lowerG ,⊗ id)) (sym (⊗-unit-l⊗-intro _))
-  uB-lem (suc n-1) f =
-    cong (_∘g ((⟜-intro ⊗-unit-l ∘g lowerG)) ,⊗ f) (⟜-β _)
+        (upgradeBuilder n ∘g ⟜-intro ⊗-unit-l) ,⊗ id
+        ≡ f ∘g ⊗-unit-l
+  upgradeNilBuilder zero f =
+    cong (_∘g (id ,⊗ f)) (⟜-β _)
+    ∙ sym (⊗-unit-l⊗-intro _)
+  upgradeNilBuilder (suc n) f =
+    cong (_∘g ((⟜-intro ⊗-unit-l)) ,⊗ f) (⟜-β _)
     ∙ cong ((⟜-app ,⊗ id) ∘g_) (cong (_∘g (id ,⊗ f)) (⊗-assoc⊗-intro {f' = id}{f'' = id}))
-    ∙ (λ i → (⟜-β ⊗-unit-l i ∘g lowerG ,⊗ id) ,⊗ id ∘g ⊗-assoc ∘g id ,⊗ f)
+    ∙ ( (λ i → (⟜-β ⊗-unit-l i) ,⊗ id ∘g ⊗-assoc ∘g id ,⊗ f))
     ∙ cong (_∘g (id ,⊗ f)) (cong ((⊗-unit-l ,⊗ id) ∘g_) (sym (⊗-assoc⊗-intro {f' = id}{f'' = id})))
-    ∙ cong (_∘g lowerG ,⊗ f) ⊗-unit-l⊗-assoc
-    ∙ cong (_∘g lowerG ,⊗ id) (sym (⊗-unit-l⊗-intro _))
+    ∙ cong (_∘g id ,⊗ f) ⊗-unit-l⊗-assoc
+    ∙ sym (⊗-unit-l⊗-intro _)
+
+  upgradeBalancedBuilder :
+    ∀ n (f : Trace true n ⊢ GenDyck n)
+    → (⟜-app ∘g id ,⊗ f)
+      ∘g (upgradeBuilder n ∘g ⟜-intro (
+          BALANCED
+          ∘g lowerG {ℓ-zero} ,⊗ (⟜-app ∘g lowerG{ℓ-zero} ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ lowerG {ℓ-zero} ,⊗ (⟜-app ∘g lowerG {ℓ-zero} ,⊗ id)
+          ∘g ⊗-assoc⁻4))
+         ,⊗ id
+      ≡ genBALANCED n
+        ∘g id ,⊗ (⟜-app ∘g id ,⊗ (NIL ,⊗ id ∘g ⊗-unit-l⁻))
+        ∘g id ,⊗ id ,⊗ id ,⊗ ⟜-app
+        ∘g lowerG ,⊗ (upgradeBuilder (suc n) ∘g lowerG) ,⊗ lowerG ,⊗ ((upgradeBuilder n) ∘g lowerG) ,⊗ f
+        ∘g ⊗-assoc⁻4
+  upgradeBalancedBuilder zero f =
+    cong (_∘g (id ,⊗ f)) (⟜-β _)
+    ∙ (λ i → BALANCED
+       ∘g lowerG ,⊗ (⟜-app ∘g id ,⊗ NIL ∘g ⊗-unit-r⁻⊗-intro {f = lowerG} (~ i)) ,⊗ lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ id)
+       ∘g ⊗-assoc⁻4
+       ∘g id ,⊗ f
+      )
+    ∙ (λ i → BALANCED ∘g
+      lowerG ,⊗ (⟜-app ∘g id ,⊗ NIL) ,⊗ id ∘g
+      id ,⊗ ⊗-assoc⊗-unit-l⁻ (~ i) ∘g
+      id ,⊗ id ,⊗ id ,⊗ ⟜-app ∘g
+      id ,⊗ lowerG ,⊗ lowerG ,⊗ (id ∘g lowerG) ,⊗ id
+      ∘g ⊗-assoc⁻4
+      ∘g id ,⊗ f)
+    ∙ (λ i → BALANCED
+      ∘g id ,⊗ ⟜-app ,⊗ id
+      ∘g id ,⊗ ((id ,⊗ NIL) ,⊗ id)
+      ∘g id ,⊗ (⊗-assoc ∘g id ,⊗ ⊗-unit-l⁻)  -- 
+      ∘g id ,⊗ id ,⊗ id ,⊗ ⟜-app
+      ∘g lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ (id ∘g lowerG) ,⊗ id ∘g ⊗-assoc⁻4⊗-intro {f = id}{f' = id}{f'' = id}{f''' = id}{f'''' = f} i)
+    ∙ (λ i → BALANCED
+      ∘g id ,⊗ (⟜-app ,⊗ id)
+      ∘g id ,⊗ ⊗-assoc⊗-intro {f = id}{f' = NIL}{f'' = id} (~ i)
+      ∘g id ,⊗ (id ,⊗ ⊗-unit-l⁻)
+      ∘g id ,⊗ id ,⊗ id ,⊗ ⟜-app
+      ∘g lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ (id ∘g lowerG) ,⊗ f ∘g ⊗-assoc⁻4
+          )
+    ∙ λ i → BALANCED
+      ∘g id ,⊗ (⟜-β (⟜-app ,⊗ id ∘g ⊗-assoc) (~ i))
+      ∘g id ,⊗ (id ,⊗ (NIL ,⊗ id ∘g ⊗-unit-l⁻))
+      ∘g id ,⊗ id ,⊗ id ,⊗ ⟜-app
+      ∘g lowerG ,⊗ (lowerG) ,⊗ lowerG ,⊗ (id ∘g lowerG) ,⊗ f
+      ∘g ⊗-assoc⁻4
+  upgradeBalancedBuilder (suc n) f = {!!}
 
 genAppend' : IndDyck ⊢ &[ n ∈ _ ] (GenDyck n ⟜ GenDyck n)
 genAppend' = (&ᴰ-intro upgradeBuilder) ∘g append'
@@ -431,14 +487,39 @@ genRetr = ind' DyckTy PileAlg
       f1-is-homo : f1 ∘g appendAlg _ ≡ PileAlg _ ∘g map (DyckTy _) λ _ → f1
       f1-is-homo = ⊕ᴰ≡ _ _ λ
         { nil' → &ᴰ≡ _ _ λ n →
-          ⟜-intro (⟜-app ∘g id ,⊗ genMkTree) ∘g upgradeBuilder n ∘g ⟜-intro ⊗-unit-l ∘g lowerG
-            ≡⟨ ⟜≡ _ _
+          ⟜≡ _ _
               (cong (_∘g ((upgradeBuilder n ∘g ⟜-intro ⊗-unit-l ∘g lowerG) ,⊗ id)) (⟜-β _)
-              ∙ uB-lem n genMkTree
-              ∙ cong (_∘g (lowerG ,⊗ id)) (sym (⟜-β _)))
-             ⟩
-          ⟜-intro (genMkTree ∘g ⊗-unit-l) ∘g lowerG ∎
-        ; balanced' → {!!} }
+              ∙ cong (_∘g (lowerG ,⊗ id)) (upgradeNilBuilder n genMkTree ∙ sym (⟜-β _)))
+        ; balanced' → &ᴰ≡ _ _ λ n → ⟜≡ _ _
+          ( cong (_∘g ((upgradeBuilder n ∘g ⟜-intro (BALANCED ∘g lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ id) ∘g ⊗-assoc⁻4)) ,⊗ id)) (⟜-β _)
+          ∙ upgradeBalancedBuilder n genMkTree
+          ∙ {!!}
+          ∙ cong ((genBALANCED n ∘g id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)) ∘g_) (sym (⊗-assoc⁻4⊗-intro {f = lowerG}{f' = f1 ∘g lowerG}{f'' = lowerG}{f''' = f1 ∘g lowerG}{f'''' = id}))
+{-
+      (genBALANCED n ∘g
+       id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
+       ∘g ⊗-assoc⁻4
+       ∘g (lowerG ,⊗ f1 ∘g lowerG ,⊗ lowerG ,⊗ f1 ∘g lowerG) ,⊗ id)
+ -}
+          ∙ cong (_∘g ((id ,⊗ (liftG {ℓ-zero} ∘g f1 ∘g lowerG) ,⊗ id ,⊗ (liftG {ℓ-zero} ∘g f1 ∘g lowerG))) ,⊗ id) (sym (⟜-β _)))
+
+          --  (⟜-app ∘g (⟜-intro (⟜-app ∘g id ,⊗ genMkTree) ∘g upgradeBuilder n ∘g ⟜-intro (BALANCED ∘g lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ id) ∘g ⊗-assoc⁻4)) ,⊗ id
+          --   ≡⟨ {!!} ⟩
+          --   ⟜-app
+          -- ∘g (⟜-intro (genBALANCED n
+          --             ∘g  id ,⊗ (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
+          --             ∘g ⊗-assoc⁻4
+          --             ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ lowerG) ,⊗ id)
+          --    ∘g id ,⊗ (liftG {ℓ-zero} ∘g f1 ∘g lowerG) ,⊗ id ,⊗ (liftG {ℓ-zero} ∘g f1 ∘g lowerG))
+          --    ,⊗ id
+          --  ∎)
+          }
+
+      -- ⟜-app ∘g
+      -- (&ᴰ-π n ∘g
+      --  (PileAlg tt ∘g map (DyckTy tt) (λ _ → f1)) ∘g ⊕ᴰ-in balanced')
+      -- ,⊗ id
+
 
 Dyck≅Trace : StrongEquivalence IndDyck (Trace true 0)
 Dyck≅Trace =

--- a/code/cubical/Examples/Indexed/Dyck.agda
+++ b/code/cubical/Examples/Indexed/Dyck.agda
@@ -249,7 +249,7 @@ GenDyck (suc n-1) = IndDyck ⊗ literal RP ⊗ GenDyck n-1
 opaque
   genBALANCED : ∀ n → literal LP ⊗ IndDyck ⊗ literal RP ⊗ GenDyck n ⊢ GenDyck n
   genBALANCED zero   = BALANCED
-  genBALANCED (suc n) = ⟜4⊗ (⟜4-intro-ε BALANCED)
+  genBALANCED (suc n) = BALANCED ,⊗ id ∘g ⊗-assoc4
 
 upgradeBuilder : ∀ n → (IndDyck ⟜ IndDyck) ⊢ GenDyck n ⟜ GenDyck n
 upgradeBuilder zero = id
@@ -326,7 +326,62 @@ opaque
       ∘g id ,⊗ id ,⊗ id ,⊗ ⟜-app
       ∘g lowerG ,⊗ (lowerG) ,⊗ lowerG ,⊗ (id ∘g lowerG) ,⊗ f
       ∘g ⊗-assoc⁻4
-  upgradeBalancedBuilder (suc n) f = {!!}
+  upgradeBalancedBuilder (suc n) f =
+    (λ i →
+      (⟜-β (⟜-app ,⊗ id ∘g ⊗-assoc) i) ∘g
+        (⟜-intro (BALANCED ∘g lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ id)
+        ∘g ⊗-assoc⁻4))
+        ,⊗ f)
+    ∙ (λ i →
+      ⟜-app ,⊗ id
+      ∘g ⊗-assoc⊗-intro {f = ⟜-intro (BALANCED ∘g lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ id) ∘g ⊗-assoc⁻4)}{f' = id}{f'' = id} i
+      ∘g id ,⊗ f)
+    ∙ (λ i →
+        (⟜-β (BALANCED ∘g lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ id) ∘g ⊗-assoc⁻4) i) ,⊗ id
+        ∘g ⊗-assoc
+        ∘g id ,⊗ f
+      )
+    ∙ (λ i →
+       BALANCED ,⊗ id
+       ∘g (lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ id)) ,⊗ id
+       ∘g ⊗-assoc⁻4⊗-assoc i
+       ∘g id ,⊗ f)
+    ∙ (λ i → BALANCED ,⊗ id
+        ∘g ⊗-assoc4⊗-intro {f = lowerG}{f' = ⟜-app ∘g lowerG ,⊗ NIL ∘g ⊗-unit-r⁻}{f'' = lowerG}{f''' = (⟜-app ∘g lowerG ,⊗ id)}{f'''' = id} (~ i)
+        ∘g id ,⊗ id ,⊗ id ,⊗ ⊗-assoc
+        ∘g ⊗-assoc⁻4
+        ∘g id ,⊗ f)
+    ∙ (λ i → BALANCED ,⊗ id
+        ∘g ⊗-assoc4
+        ∘g lowerG ,⊗ (⟜-app ∘g lowerG ,⊗ NIL ∘g ⊗-unit-r⁻) ,⊗ lowerG ,⊗ ((⟜-app ∘g lowerG ,⊗ id) ,⊗ id)
+        ∘g id ,⊗ id ,⊗ id ,⊗ ⊗-assoc
+        ∘g ⊗-assoc⁻4⊗-intro {f = id}{f' = id}{f'' = id}{f''' = id}{f'''' = f} i)
+    ∙ (λ i → BALANCED ,⊗ id
+        ∘g ⊗-assoc4
+        ∘g lowerG ,⊗ ((⟜-app ∘g (id ,⊗ NIL) ∘g ⊗-unit-r⁻⊗-intro {f = lowerG} (~ i)) ,⊗ lowerG ,⊗ ((⟜-app ∘g lowerG ,⊗ id) ,⊗ id ∘g ⊗-assoc ∘g id ,⊗ f))
+        ∘g ⊗-assoc⁻4)
+    ∙ (
+      λ i → BALANCED ,⊗ id
+        ∘g ⊗-assoc4
+        ∘g id ,⊗ (⟜-app ,⊗ id)
+        ∘g id ,⊗ ((id ,⊗ NIL) ,⊗ id)
+        ∘g id ,⊗ ⊗-assoc⊗-unit-l⁻ (~ i)
+        ∘g lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ ((⟜-app ∘g lowerG ,⊗ id) ,⊗ id ∘g ⊗-assoc ∘g id ,⊗ f)
+        ∘g ⊗-assoc⁻4
+      )
+    ∙ (λ i →
+        BALANCED ,⊗ id
+        ∘g ⊗-assoc4
+        ∘g id ,⊗ (⟜-app ,⊗ id)
+        ∘g id ,⊗ (⊗-assoc⊗-intro {f = id}{f' = NIL}{f'' = id} (~ i))
+        ∘g id ,⊗ (id ,⊗ ⊗-unit-l⁻)
+        ∘g lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ (⟜-app ,⊗ id ∘g (⊗-assoc⊗-intro {f = lowerG}{f' = id}{f'' = id} (~ i)) ∘g id ,⊗ f)
+        ∘g ⊗-assoc⁻4
+      )
+    ∙ λ i → (BALANCED ,⊗ id ∘g ⊗-assoc4) ∘g
+      id ,⊗ (⟜-β (⟜-app ,⊗ id ∘g ⊗-assoc) (~ i) ∘g id ,⊗ (NIL ,⊗ id ∘g ⊗-unit-l⁻)) ∘g
+      lowerG ,⊗ (lowerG) ,⊗ lowerG ,⊗ (⟜-β (⟜-app ,⊗ id ∘g ⊗-assoc) (~ i) ∘g lowerG ,⊗ f)
+      ∘g ⊗-assoc⁻4
 
 genAppend' : IndDyck ⊢ &[ n ∈ _ ] (GenDyck n ⟜ GenDyck n)
 genAppend' = (&ᴰ-intro upgradeBuilder) ∘g append'

--- a/code/cubical/Examples/Indexed/Dyck.agda
+++ b/code/cubical/Examples/Indexed/Dyck.agda
@@ -84,7 +84,7 @@ append-nil-r' = ind-id' DyckTy (compHomo DyckTy (initialAlgebra DyckTy) appendAl
         (NIL ∘g ⊗-unit-l ∘g ⊗-unit-r⁻ ∘g lowerG)
           ≡⟨ cong (NIL ∘g_) (cong (_∘g lowerG) ⊗-unit-lr⁻) ⟩
         NIL ∘g lowerG
-        ∎ 
+        ∎
         ; balanced' →
         cong ((⟜-app ∘g id ,⊗ NIL) ∘g_) ⊗-unit-r⁻⊗-intro
         ∙ cong (_∘g id ,⊗ NIL ∘g ⊗-unit-r⁻) (⟜-β _)
@@ -166,7 +166,7 @@ printAlg b n = ⊕ᴰ-elim λ
 
 print : ∀ {n b} → Trace b n ⊢ string
 print = rec (TraceTys _) (printAlg _) _
- 
+
 ⊕ᴰAlg : ∀ b → Algebra (TraceTys b) (λ n → ⊕[ b' ∈ _ ] Trace b' n)
 ⊕ᴰAlg b n = ⊕ᴰ-elim (λ
   { (eof' Eq.refl Eq.refl) → ⊕ᴰ-in true ∘g EOF ∘g lowerG
@@ -194,7 +194,7 @@ print = rec (TraceTys _) (printAlg _) _
       ; (leftovers' Eq.refl n-1 Eq.refl) → refl
       ; open' → refl
       ; (close' n-1 Eq.refl) → refl
-      ; (unexpected' Eq.refl Eq.refl) → refl }) 
+      ; (unexpected' Eq.refl Eq.refl) → refl })
 
 parseHomo : ∀ b → Homomorphism (TraceTys b) (printAlg b) (⊕ᴰAlg b)
 parseHomo b .fst n = &ᴰ-π n ∘g parse
@@ -202,7 +202,7 @@ parseHomo b .snd n = pf where
   opaque
     unfolding KL*r-elim ⊕ᴰ-distR CONS ⊤
     pf : &ᴰ-π n ∘g parse ∘g printAlg b n
-       ≡ ⊕ᴰAlg b n ∘g map (TraceTys b n) (λ n → &ᴰ-π n ∘g parse) 
+       ≡ ⊕ᴰAlg b n ∘g map (TraceTys b n) (λ n → &ᴰ-π n ∘g parse)
     pf = ⊕ᴰ≡ _ _ λ
       { (eof' Eq.refl Eq.refl) → refl
       ; (close' n-1 Eq.refl) → refl
@@ -311,7 +311,7 @@ opaque
     ∙ (λ i → BALANCED
       ∘g id ,⊗ ⟜-app ,⊗ id
       ∘g id ,⊗ ((id ,⊗ NIL) ,⊗ id)
-      ∘g id ,⊗ (⊗-assoc ∘g id ,⊗ ⊗-unit-l⁻)  -- 
+      ∘g id ,⊗ (⊗-assoc ∘g id ,⊗ ⊗-unit-l⁻)  --
       ∘g id ,⊗ id ,⊗ id ,⊗ ⟜-app
       ∘g lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ (id ∘g lowerG) ,⊗ id ∘g ⊗-assoc⁻4⊗-intro {f = id}{f' = id}{f'' = id}{f''' = id}{f'''' = f} i)
     ∙ (λ i → BALANCED
@@ -446,6 +446,14 @@ buildTraceAlg _ = ⊕ᴰ-elim (λ
 buildTrace : IndDyck ⊢ TraceBuilder _
 buildTrace = rec DyckTy buildTraceAlg _
 
+-- buildTraceβBalanced :
+--   buildTrace ∘g roll ∘g ⊕ᴰ-in balanced'
+--   ≡ &ᴰ-intro λ n → ⟜-intro
+--     (({!\!}
+--      ∘g ⊗-assoc⁻4
+--     )
+--     ∘g (lowerG ,⊗ (buildTrace ∘g lowerG) ,⊗ lowerG ,⊗ (buildTrace ∘g lowerG)) ,⊗ id)
+
 -- we then extend the builder to generalized trees, which *adds*
 -- closed parens to the trace.
 genBuildTrace : ∀ m → GenDyck m ⊢ &[ n ∈ _ ] (Trace true (m + n) ⟜ Trace true n)
@@ -537,8 +545,8 @@ PileAlg' _ = ⊕ᴰ-elim λ
   the balanced case as a recurrence because we need to know the left
   subcall inductively
 
-  
-  
+
+
 -}
 
 lhs rhs : IndDyck ⊢ &[ n ∈ _ ] (GenDyck n ⟜ Trace true n)
@@ -550,10 +558,6 @@ pfAlg : Algebra DyckTy (λ _ → equalizer lhs rhs)
 pfAlg _ =
   eq-intro _ _ (roll ∘g map (DyckTy _) (λ _ → eq-π _ _))
     pf
-  -- (⊕ᴰ≡ _ _ (λ
-  --   { nil' → nil-case
-  --   ; balanced' → {!balanced-case!} }))
-
   where
     opaque
       unfolding ⊗-intro
@@ -566,7 +570,44 @@ pfAlg _ =
             ((λ i → genMkTree n ∘g ⟜-β ⊗-unit-l i ∘g lowerG ,⊗ id)
             ∙ λ i → upgradeNilBuilder n (genMkTree n) (~ i) ∘g lowerG ,⊗ id)
           ∙ sym ⟜-intro-natural
-        ; balanced' → {!!} }
+        ; balanced' → &ᴰ≡ _ _ λ n →
+          ⟜-intro-natural ∙
+          cong ⟜-intro
+            ( (λ i → genMkTree n
+              ∘g ⟜-β (OPEN
+                ∘g id ,⊗ (⟜-app ∘g &ᴰ-π (suc n) ,⊗ id)
+                ∘g id ,⊗ id ,⊗ CLOSE
+                ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
+                ∘g ⊗-assoc⁻4
+                ∘g (lowerG ,⊗ lowerG {ℓ-zero} ,⊗ lowerG ,⊗ lowerG {ℓ-zero}) ,⊗ id) i
+              ∘g (id ,⊗ (liftG {ℓ-zero} ∘g buildTrace ∘g eq-π lhs rhs ∘g lowerG) ,⊗ id ,⊗ ((liftG {ℓ-zero} ∘g buildTrace ∘g eq-π lhs rhs ∘g lowerG))) ,⊗ id)
+            ∙ (λ i → genBALANCED n
+                ∘g id ,⊗ genMkTree (suc n)
+                ∘g id ,⊗ (⟜-app ∘g &ᴰ-π (suc n) ,⊗ id)
+                ∘g id ,⊗ id ,⊗ CLOSE
+                ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
+                ∘g ⊗-assoc⁻4⊗-intro {f = lowerG}{f' = buildTrace ∘g eq-π lhs rhs ∘g lowerG}{f'' = lowerG}{f''' = buildTrace ∘g eq-π lhs rhs ∘g lowerG}{f'''' = id} i)
+            ∙ (λ i → genBALANCED n
+                ∘g id ,⊗ (⟜-β (genMkTree (suc n) ∘g ⟜-app) (~ i) ∘g (&ᴰ-π (suc n) ∘g (buildTrace ∘g eq-π lhs rhs)) ,⊗ id)
+                ∘g id ,⊗ id ,⊗ CLOSE
+                ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
+                ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ (buildTrace ∘g eq-π lhs rhs ∘g lowerG) ,⊗ id)
+                ∘g ⊗-assoc⁻4)
+            ∙ (λ i → genBALANCED n
+                ∘g id ,⊗ (⟜-app ∘g (&ᴰ-π (suc n) ∘g eq-π-pf lhs rhs i) ,⊗ id)
+                ∘g id ,⊗ id ,⊗ CLOSE
+                ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
+                ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ (buildTrace ∘g eq-π lhs rhs ∘g lowerG) ,⊗ id)
+                ∘g ⊗-assoc⁻4)
+            ∙ (λ i → genBALANCED n
+                ∘g id ,⊗ (⟜-app ∘g (&ᴰ-π (suc n) ∘g rhs ∘g eq-π lhs rhs) ,⊗ id)
+                ∘g id ,⊗ id ,⊗ CLOSE
+                ∘g id ,⊗ id ,⊗ id ,⊗ (⟜-app ∘g &ᴰ-π n ,⊗ id)
+                ∘g (lowerG ,⊗ lowerG ,⊗ lowerG ,⊗ (buildTrace ∘g eq-π lhs rhs ∘g lowerG) ,⊗ id)
+                ∘g ⊗-assoc⁻4)
+            ∙ {!!})
+          ∙ sym ⟜-intro-natural
+        }
 
 genRetr :
   Path (IndDyck ⊢ &[ n ∈ _ ] (GenDyck n ⟜ Trace true n))
@@ -618,7 +659,7 @@ genRetr = equalizer-section _ _
 --         {!!}
 --         ∙ ((λ i → (⟜-β (genMkTree 0 ∘g ⟜-app) (~ i) ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻) ,⊗ id ,⊗ (⟜-β (genMkTree n ∘g ⟜-app) (~ i) ∘g &ᴰ-π n ,⊗ id)))
 --         ∙ (λ i → (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻⊗-intro {f = f2}(~ i)) ,⊗ id ,⊗ (⟜-app ∘g (f2⟨ n ⟩) ,⊗ id))
-        
+
 --       f2-is-homo : f2 ∘g buildTraceAlg _ ≡ PileAlg _ ∘g map (DyckTy _) (λ _ → f2)
 --       f2-is-homo = &ᴰ≡ _ _ λ n →
 --         ⊕ᴰ≡ _ _ λ
@@ -690,7 +731,7 @@ genRetr = equalizer-section _ _
 --                  ,⊗ id
 --                  ,⊗ (⟜-β (⟜-app ∘g id ,⊗ genMkTree n) (~ i) ∘g upgradeBuilder n ,⊗ id))
 --         ∙ λ i → (⟜-app ∘g &ᴰ-π 0 ,⊗ EOF ∘g ⊗-unit-r⁻⊗-intro {f = f1} (~ i)) ,⊗ id ,⊗ (⟜-app ∘g (&ᴰ-π n ∘g f1) ,⊗ id)
-  
+
 --       f1-is-homo : f1 ∘g appendAlg _ ≡ PileAlg _ ∘g map (DyckTy _) λ _ → f1
 --       f1-is-homo = ⊕ᴰ≡ _ _ λ
 --         { nil' → &ᴰ≡ _ _ λ n →

--- a/code/cubical/Grammar/Dependent/Base.agda
+++ b/code/cubical/Grammar/Dependent/Base.agda
@@ -70,6 +70,12 @@ module _ {A : Type ℓS} {g : Grammar ℓG}{h : A → Grammar ℓH} where
     → f ≡ f'
   ⊕ᴰ≡ f f' fa≡fa' i w x = fa≡fa' (x .fst) i w (x .snd)
 
+  &ᴰ≡ : (f f' : g ⊢ (&[ a ∈ A ] h a))
+    → (∀ a → &ᴰ-π a ∘g f ≡ &ᴰ-π a ∘g f')
+    → f ≡ f'
+  &ᴰ≡ f f' f≡ i w x a = f≡ a i w x
+
+
 ⊕ᴰ-elim∘g :
   ∀ {A : Type ℓ}{g : Grammar ℓ'}{h : A → Grammar ℓ''}{k : Grammar ℓ'''}
   → {f' : ∀ a → h a ⊢ g}

--- a/code/cubical/Grammar/Dependent/Base.agda
+++ b/code/cubical/Grammar/Dependent/Base.agda
@@ -16,7 +16,7 @@ open import Grammar.Literal Alphabet
 
 private
   variable
-    ℓG ℓH ℓS : Level
+    ℓG ℓH ℓS ℓ ℓ' ℓ'' ℓ''' : Level
 
 LinearΠ : {A : Type ℓS} → (A → Grammar ℓG) → Grammar (ℓ-max ℓS ℓG)
 LinearΠ {A = A} f w = ∀ (a : A) → f a w
@@ -69,3 +69,10 @@ module _ {A : Type ℓS} {g : Grammar ℓG}{h : A → Grammar ℓH} where
     → (∀ a → f ∘g ⊕ᴰ-in a ≡ f' ∘g ⊕ᴰ-in a)
     → f ≡ f'
   ⊕ᴰ≡ f f' fa≡fa' i w x = fa≡fa' (x .fst) i w (x .snd)
+
+⊕ᴰ-elim∘g :
+  ∀ {A : Type ℓ}{g : Grammar ℓ'}{h : A → Grammar ℓ''}{k : Grammar ℓ'''}
+  → {f' : ∀ a → h a ⊢ g}
+  → {f : g ⊢ k}
+  → f ∘g ⊕ᴰ-elim f' ≡ ⊕ᴰ-elim (λ a → f ∘g f' a)
+⊕ᴰ-elim∘g = ⊕ᴰ≡ _ _ (λ a → refl)

--- a/code/cubical/Grammar/Equalizer.agda
+++ b/code/cubical/Grammar/Equalizer.agda
@@ -1,0 +1,67 @@
+{- Equalizers are "solutions" to equations between two terms. -}
+
+{-
+  These look a bit like dependent/refinement types because they can
+  be defined in terms of Sigma and equality, but you can have them in
+  linear language.
+-}
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+
+module Grammar.Equalizer (Alphabet : hSet ℓ-zero) where
+
+open import Cubical.Data.List
+open import Cubical.Data.Sigma
+open import Cubical.Data.Nat
+
+open import Grammar.Base Alphabet
+open import Grammar.LinearProduct Alphabet
+open import Grammar.Epsilon Alphabet
+open import Term.Base Alphabet
+open import Term.Bilinear Alphabet
+
+private
+  variable
+    ℓg ℓh ℓk ℓl ℓ ℓ' : Level
+    g g' g'' g1 g2 g3 g4 g5 : Grammar ℓg
+    h h' h'' : Grammar ℓh
+    k : Grammar ℓk
+    f f' f'' : g ⊢ h
+    l : Grammar ℓl
+
+module _ {g : Grammar ℓ}{h : Grammar ℓ'} (f f' : g ⊢ h) where
+  opaque
+    equalizer : Grammar (ℓ-max ℓ ℓ')
+    equalizer w = Σ[ x ∈ g w ] f w x ≡ f' w x
+
+    eq-π : equalizer ⊢ g
+    eq-π = λ w z → z .fst
+
+    eq-π-pf : f ∘g eq-π ≡ f' ∘g eq-π
+    eq-π-pf i w x = x .snd i
+
+  module _ (f'' : k ⊢ g) (p : f ∘g f'' ≡ f' ∘g f'') where
+    opaque
+      unfolding equalizer
+      eq-intro : k ⊢ equalizer
+      eq-intro w x .fst = f'' w x
+      eq-intro w x .snd i = p i w x
+ 
+      eq-β : eq-π ∘g eq-intro ≡ f''
+      eq-β = refl
+
+  module _ (f'' : k ⊢ equalizer) where
+    opaque
+      unfolding equalizer eq-intro
+      eq-η : f'' ≡ eq-intro (eq-π ∘g f'') λ i → eq-π-pf i ∘g f''
+      eq-η i = f'' 
+
+  equalizer-section :
+    ∀ (f'' : g ⊢ equalizer) →
+    (eq-π ∘g f'' ≡ id)
+    → f ≡ f'
+  equalizer-section f'' p =
+    cong (f ∘g_) (sym p)
+    ∙ cong (_∘g f'') eq-π-pf
+    ∙ cong (f' ∘g_) p

--- a/code/cubical/Grammar/LinearFunction.agda
+++ b/code/cubical/Grammar/LinearFunction.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --allow-unsolved-metas #-}
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Isomorphism
@@ -175,6 +174,7 @@ opaque
 
 opaque
   unfolding ⟜-intro
+
   ⟜-mapCod-precomp : (e : g ⊢ h)(f : k ⊗ l ⊢ g) →
     ⟜-mapCod e ∘g ⟜-intro f ≡ ⟜-intro (e ∘g f)
   ⟜-mapCod-precomp {g = g}{h = h}{l = l} e f =
@@ -182,23 +182,19 @@ opaque
     cong (e (w ++ w')) (transportRefl (⟜-intro {h = l} f w p w' q))
 
 opaque
-  unfolding ⟜-intro ⊗-unit-r⁻
+  unfolding ⊗-intro
   ⟜-mapCod-postcompε : (e : g ⊢ h)(f : ε ⊢ g) →
     (⟜-app ∘g id ,⊗ f ∘g ⊗-unit-r⁻) ∘g ⟜-mapCod e ≡
       e ∘g ⟜-app ∘g id ,⊗ f ∘g ⊗-unit-r⁻
   ⟜-mapCod-postcompε e f =
-    (⟜-app ∘g id ,⊗ f ∘g ⊗-unit-r⁻) ∘g ⟜-mapCod e
-      ≡⟨ {!!} ⟩
-    e ∘g ⟜-app ∘g id ,⊗ f ∘g ⊗-unit-r⁻
-    ∎
-    -- Some gross equality of transports
-    -- This should follow from another combinator.
-
+    cong ((⟜-app ∘g id ,⊗ f) ∘g_) ⊗-unit-r⁻⊗-intro
+    ∙ (λ i → ⟜-β (e ∘g ⟜-app) i ∘g (id ,⊗ f) ∘g ⊗-unit-r⁻)
 
 ⟜-mapDom : g ⊢ h → k ⟜ h ⊢ k ⟜ g
 ⟜-mapDom f = ⟜-intro (⟜-app ∘g id ,⊗ f)
 
 opaque
+  -- why do we need to unfold ⟜-intro here?
   unfolding ⟜-intro
   ⟜-mapDom-precomp : (e : g ⊢ h)(f : k ⊗ h ⊢ h) →
     ⟜-mapDom e ∘g ⟜-intro f ≡ ⟜-intro (f ∘g id ,⊗ e)
@@ -206,12 +202,13 @@ opaque
       ⟜-η {h = h} (⟜-intro {h = g}(f ∘g id ,⊗ e))
 
 opaque
-  unfolding ⟜-intro ⊗-unit-r⁻
+  unfolding ⊗-intro
   ⟜-mapDom-postcompε : (e : g ⊢ h)(f : ε ⊢ g) →
     (⟜-app ∘g id ,⊗ f ∘g ⊗-unit-r⁻) ∘g ⟜-mapDom {k = k} e ≡
       ⟜-app ∘g id ,⊗ (e ∘g f) ∘g ⊗-unit-r⁻
-  ⟜-mapDom-postcompε e f = {!!}
-
+  ⟜-mapDom-postcompε e f =
+    cong ((⟜-app ∘g id ,⊗ f) ∘g_) ⊗-unit-r⁻⊗-intro
+    ∙ λ i → ⟜-β (⟜-app ∘g id ,⊗ e) i ∘g (id ,⊗ f) ∘g ⊗-unit-r⁻
 
 ⟜-curry :
   k ⟜ (g ⊗ h) ⊢ k ⟜ h ⟜ g
@@ -273,7 +270,11 @@ opaque
 ⊸0⊗ : ε ⊢ k → l ⊢ l ⊗ k
 ⊸0⊗ f = id ,⊗ f ∘g ⊗-unit-r⁻
 
-⟜-app⊸0⊗ :
-  ∀ (f : g ⊗ h ⊢ k) (x : ε ⊢ h) → 
-  ⟜-app ∘g ⊸0⊗ x ∘g ⟜-intro f ≡ f ∘g ⊸0⊗ x
-⟜-app⊸0⊗ = {!!}
+opaque
+  unfolding ⊗-intro
+  ⟜-app⊸0⊗ :
+    ∀ (f : g ⊗ h ⊢ k) (x : ε ⊢ h) →
+    ⟜-app ∘g ⊸0⊗ x ∘g ⟜-intro f ≡ f ∘g ⊸0⊗ x
+  ⟜-app⊸0⊗ f x =
+    cong ((⟜-app ∘g id ,⊗ x) ∘g_) ⊗-unit-r⁻⊗-intro
+    ∙ λ i → ⟜-β f i ∘g (id ,⊗ x) ∘g ⊗-unit-r⁻

--- a/code/cubical/Grammar/LinearFunction.agda
+++ b/code/cubical/Grammar/LinearFunction.agda
@@ -261,6 +261,9 @@ opaque
 ⟜2⊗ : ε ⊢ k ⟜ g2 ⟜ g1 → g1 ⊗ g2 ⊗ l ⊢ k ⊗ l
 ⟜2⊗ f = ⟜-app-l ∘g ⟜1⊗ f
 
+⟜2⊗' : g1 ⊗ g2 ⊢ k → g1 ⊗ g2 ⊗ l ⊢ k ⊗ l
+⟜2⊗' f = f ,⊗ id ∘g ⊗-assoc
+
 ⟜3⊗ : ε ⊢ k ⟜ g3 ⟜ g2 ⟜ g1 → g1 ⊗ g2 ⊗ g3 ⊗ l ⊢ k ⊗ l
 ⟜3⊗ f = ⟜-app-l ∘g ⟜2⊗ f
 
@@ -270,6 +273,7 @@ opaque
 ⊸0⊗ : ε ⊢ k → l ⊢ l ⊗ k
 ⊸0⊗ f = id ,⊗ f ∘g ⊗-unit-r⁻
 
+
 opaque
   unfolding ⊗-intro
   ⟜-app⊸0⊗ :
@@ -278,3 +282,11 @@ opaque
   ⟜-app⊸0⊗ f x =
     cong ((⟜-app ∘g id ,⊗ x) ∘g_) ⊗-unit-r⁻⊗-intro
     ∙ λ i → ⟜-β f i ∘g (id ,⊗ x) ∘g ⊗-unit-r⁻
+
+⟜≡ : ∀ (f f' : g ⊢ k ⟜ h)
+  → ⟜-app ∘g (f ,⊗ id) ≡ ⟜-app ∘g (f' ,⊗ id)
+  → f ≡ f'
+⟜≡ f f' p =
+  sym (⟜-η f)
+  ∙ cong ⟜-intro p
+  ∙ ⟜-η f'

--- a/code/cubical/Grammar/LinearFunction.agda
+++ b/code/cubical/Grammar/LinearFunction.agda
@@ -173,6 +173,46 @@ opaque
 ⟜-mapCod : k ⊢ l → k ⟜ g ⊢ l ⟜ g
 ⟜-mapCod f = ⟜-intro (f ∘g ⟜-app)
 
+opaque
+  unfolding ⟜-intro
+  ⟜-mapCod-precomp : (e : g ⊢ h)(f : k ⊗ l ⊢ g) →
+    ⟜-mapCod e ∘g ⟜-intro f ≡ ⟜-intro (e ∘g f)
+  ⟜-mapCod-precomp {g = g}{h = h}{l = l} e f =
+    funExt λ w → funExt λ p → funExt λ w' → funExt λ q →
+    cong (e (w ++ w')) (transportRefl (⟜-intro {h = l} f w p w' q))
+
+opaque
+  unfolding ⟜-intro ⊗-unit-r⁻
+  ⟜-mapCod-postcompε : (e : g ⊢ h)(f : ε ⊢ g) →
+    (⟜-app ∘g id ,⊗ f ∘g ⊗-unit-r⁻) ∘g ⟜-mapCod e ≡
+      e ∘g ⟜-app ∘g id ,⊗ f ∘g ⊗-unit-r⁻
+  ⟜-mapCod-postcompε e f =
+    (⟜-app ∘g id ,⊗ f ∘g ⊗-unit-r⁻) ∘g ⟜-mapCod e
+      ≡⟨ {!!} ⟩
+    e ∘g ⟜-app ∘g id ,⊗ f ∘g ⊗-unit-r⁻
+    ∎
+    -- Some gross equality of transports
+    -- This should follow from another combinator.
+
+
+⟜-mapDom : g ⊢ h → k ⟜ h ⊢ k ⟜ g
+⟜-mapDom f = ⟜-intro (⟜-app ∘g id ,⊗ f)
+
+opaque
+  unfolding ⟜-intro
+  ⟜-mapDom-precomp : (e : g ⊢ h)(f : k ⊗ h ⊢ h) →
+    ⟜-mapDom e ∘g ⟜-intro f ≡ ⟜-intro (f ∘g id ,⊗ e)
+  ⟜-mapDom-precomp {g = g}{h = h} e f =
+      ⟜-η {h = h} (⟜-intro {h = g}(f ∘g id ,⊗ e))
+
+opaque
+  unfolding ⟜-intro ⊗-unit-r⁻
+  ⟜-mapDom-postcompε : (e : g ⊢ h)(f : ε ⊢ g) →
+    (⟜-app ∘g id ,⊗ f ∘g ⊗-unit-r⁻) ∘g ⟜-mapDom {k = k} e ≡
+      ⟜-app ∘g id ,⊗ (e ∘g f) ∘g ⊗-unit-r⁻
+  ⟜-mapDom-postcompε e f = {!!}
+
+
 ⟜-curry :
   k ⟜ (g ⊗ h) ⊢ k ⟜ h ⟜ g
 ⟜-curry {k = k} = ⟜-intro (⟜-intro {k = k} (⟜-app ∘g ⊗-assoc⁻))

--- a/code/cubical/Grammar/LinearFunction.agda
+++ b/code/cubical/Grammar/LinearFunction.agda
@@ -181,6 +181,11 @@ opaque
   g ⊢ k → ε ⊢ k ⟜ g
 ⟜-intro-ε f = ⟜-intro (f ∘g ⊗-unit-l)
 
+⟜-intro-ε-β :
+  (f : g ⊢ k)
+  → ⟜-app ∘g (⟜-intro-ε f) ,⊗ id ≡ f ∘g ⊗-unit-l
+⟜-intro-ε-β f = ⟜-β (f ∘g ⊗-unit-l)
+
 ⟜2-intro-ε :
   g1 ⊗ g2 ⊢ k → ε ⊢ k ⟜ g2 ⟜ g1
 ⟜2-intro-ε {k = k} f = ⟜-curry {k = k} ∘g ⟜-intro-ε f

--- a/code/cubical/Grammar/LinearFunction.agda
+++ b/code/cubical/Grammar/LinearFunction.agda
@@ -19,6 +19,7 @@ private
     ℓg ℓh ℓk ℓl ℓ ℓ' : Level
     g g' g'' g1 g2 g3 g4 g5 : Grammar ℓg
     h h' h'' : Grammar ℓh
+    f f' f'' : g ⊢ h
     k : Grammar ℓk
     l : Grammar ℓl
 
@@ -290,3 +291,10 @@ opaque
   sym (⟜-η f)
   ∙ cong ⟜-intro p
   ∙ ⟜-η f'
+opaque
+  unfolding ⊗-intro
+  ⟜-intro-natural :
+    ⟜-intro f ∘g f' ≡ ⟜-intro (f ∘g f' ,⊗ id)
+  ⟜-intro-natural {f = f}{f' = f'} = ⟜≡ _ _
+    ((λ i → ⟜-β f i ∘g (f' ,⊗ id))
+    ∙ sym (⟜-β _) )

--- a/code/cubical/Grammar/LinearProduct.agda
+++ b/code/cubical/Grammar/LinearProduct.agda
@@ -313,10 +313,6 @@ opaque
         (ΣPathP (refl , ⊗PathP refl refl))
 
   opaque
-    ⊗-unit-l⊗-assoc : ⊗-intro ⊗-unit-l id ∘g ⊗-assoc {h = h}{k = k}
-      ≡ ⊗-unit-l
-    ⊗-unit-l⊗-assoc = {!!}
-
     ⊗-assoc⊗-unit-l⁻ :
       ⊗-assoc {g = g}{k = k} ∘g ⊗-intro id ⊗-unit-l⁻ ≡ ⊗-intro ⊗-unit-r⁻ id
     ⊗-assoc⊗-unit-l⁻ = {!!}

--- a/code/cubical/Grammar/LinearProduct.agda
+++ b/code/cubical/Grammar/LinearProduct.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --allow-unsolved-metas #-}
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 
@@ -296,6 +297,12 @@ opaque
     ≡ ⊗-intro f (⊗-intro f' f'') ∘g ⊗-assoc⁻
   ⊗-assoc⁻⊗-intro = refl
 
+  ⊗-assoc⊗-intro : 
+    ∀ {f : g ⊢ h}{f' : g' ⊢ h'}{f'' : g'' ⊢ h''}
+    → ⊗-assoc ∘g ⊗-intro f (⊗-intro f' f'')
+      ≡ ⊗-intro (⊗-intro f f') f'' ∘g ⊗-assoc
+  ⊗-assoc⊗-intro = {!!}
+
   opaque
     unfolding ⊗-unit-r⁻
     ⊗-assoc⁻⊗-unit-r⁻ :
@@ -303,6 +310,11 @@ opaque
     ⊗-assoc⁻⊗-unit-r⁻ = funExt λ w → funExt λ p →
       ⊗≡ _ _ (≡-× refl (++-unit-r _))
         (ΣPathP (refl , ⊗PathP refl refl))
+
+  opaque
+    ⊗-unit-l⊗-assoc : ⊗-intro ⊗-unit-l id ∘g ⊗-assoc {h = h}{k = k}
+      ≡ ⊗-unit-l
+    ⊗-unit-l⊗-assoc = {!!}
 
   opaque
     unfolding ε ⊗-unit-l⁻

--- a/code/cubical/Grammar/LinearProduct.agda
+++ b/code/cubical/Grammar/LinearProduct.agda
@@ -17,6 +17,7 @@ private
     ℓg ℓh ℓk ℓl ℓ ℓ' : Level
     g g' g'' g''' g'''' g''''' : Grammar ℓg
     h h' h'' h''' h'''' h''''' : Grammar ℓh
+    f f' f'' f''' f'''' f''''' : g ⊢ h
     k : Grammar ℓk
     l : Grammar ℓl
 
@@ -360,6 +361,10 @@ infixr 20 _,⊗_
   (g ⊗ g' ⊗ g'') ⊗ g''' ⊢ g ⊗ g' ⊗ g'' ⊗ g'''
 ⊗-assoc⁻3 = id ,⊗ ⊗-assoc⁻ ∘g ⊗-assoc⁻  
 
+⊗-assoc3 :
+  g ⊗ g' ⊗ g'' ⊗ g''' ⊢ (g ⊗ g' ⊗ g'') ⊗ g'''
+⊗-assoc3 = ⊗-assoc ∘g id ,⊗ ⊗-assoc
+
 ⊗-assoc⁻3⊗-unit-r⁻ :
   ⊗-assoc⁻3 {g = g}{g' = g'}{g'' = g''} ∘g ⊗-unit-r⁻
   ≡ id ,⊗ id ,⊗ ⊗-unit-r⁻
@@ -371,6 +376,16 @@ infixr 20 _,⊗_
 ⊗-assoc⁻4 :
   (g ⊗ g' ⊗ g'' ⊗ g''') ⊗ g'''' ⊢ g ⊗ g' ⊗ g'' ⊗ g''' ⊗ g''''
 ⊗-assoc⁻4 = id ,⊗ ⊗-assoc⁻3 ∘g ⊗-assoc⁻
+
+⊗-assoc4 :
+  g ⊗ g' ⊗ g'' ⊗ g''' ⊗ g'''' ⊢ (g ⊗ g' ⊗ g'' ⊗ g''') ⊗ g''''
+⊗-assoc4 = ⊗-assoc ∘g id ,⊗ ⊗-assoc3
+
+⊗-assoc⁻4⊗-assoc :
+  ⊗-assoc⁻4 {g = g}{g' = g'}{g'' = g''}{g''' = g'''}{g'''' = g''''} ,⊗ id {g = g'''''}
+  ∘g ⊗-assoc
+  ≡ ⊗-assoc4 ∘g id ,⊗ id ,⊗ id ,⊗ ⊗-assoc ∘g ⊗-assoc⁻4
+⊗-assoc⁻4⊗-assoc = {!!}
 
 ⊗-assoc⁻4⊗-unit-r⁻ :
   ⊗-assoc⁻4 {g = g}{g' = g'}{g'' = g''}{g''' = g'''} ∘g ⊗-unit-r⁻
@@ -395,3 +410,8 @@ infixr 20 _,⊗_
   cong (id ,⊗ ⊗-assoc⁻3 ∘g_) ⊗-assoc⁻⊗-intro
   ∙ cong (_∘g ⊗-assoc⁻) (⊗-intro⊗-intro ∙ cong (⊗-intro _) ⊗-assoc⁻3⊗-intro)
   ∙ {!sym ⊗-intro⊗-intro!}
+
+⊗-assoc4⊗-intro :
+  ⊗-assoc4 ∘g f ,⊗ f' ,⊗ f'' ,⊗ f''' ,⊗ f''''
+  ≡ (f ,⊗ f' ,⊗ f'' ,⊗ f''') ,⊗ f'''' ∘g ⊗-assoc4
+⊗-assoc4⊗-intro = {!!}

--- a/code/cubical/Grammar/LinearProduct.agda
+++ b/code/cubical/Grammar/LinearProduct.agda
@@ -14,7 +14,7 @@ open import Term.Bilinear Alphabet
 private
   variable
     ℓg ℓh ℓk ℓl ℓ ℓ' : Level
-    g g' g'' : Grammar ℓg
+    g g' g'' g''' g'''' g''''' : Grammar ℓg
     h h' h'' : Grammar ℓh
     k : Grammar ℓk
     l : Grammar ℓl
@@ -88,6 +88,14 @@ opaque
     g ⊗ k ⊢ h ⊗ l
   ⊗-intro e e' _ p =
     p .fst , (e _ (p .snd .fst)) , (e' _ (p .snd .snd))
+
+  ⊗-intro⊗-intro
+    : ∀ {f : g ⊢ g'}{f' : g'' ⊢ g'''}
+        {f'' : g'''' ⊢ g}
+        {f''' : g''''' ⊢ g''}
+    → ⊗-intro f f' ∘g ⊗-intro f'' f'''
+      ≡ ⊗-intro (f ∘g f'') (f' ∘g f''')
+  ⊗-intro⊗-intro = refl
 
   opaque
     unfolding ε
@@ -212,27 +220,15 @@ opaque
       cong (_∘g ⊗-unit-r) ∘g≡ ∙
       cong (g ∘g_) (⊗-unit-rr⁻)
 
-    -- TODO this proof seems overly complicated
-    ⊗-unit-r⊗-intro :
-      (f : g ⊢ h) →
-      ⊗-unit-r ∘g ⊗-intro f id ≡ f ∘g ⊗-unit-r
-    ⊗-unit-r⊗-intro f =
-      cong-∘g⊗-unit-r⁻ (⊗-unit-r ∘g ⊗-intro f id) (f ∘g ⊗-unit-r)
-        ((⊗-unit-r ∘g ⊗-intro f id) ∘g ⊗-unit-r⁻
-          ≡⟨ refl ⟩
-          ⊗-unit-r ∘g ⊗-unit-r⁻ ∘g f
-          ≡⟨ ((λ i → ⊗-unit-r⁻r i ∘g f ∘g ⊗-unit-r⁻r (~ i))) ⟩
-        (f ∘g ⊗-unit-r) ∘g ⊗-unit-r⁻
-        ∎)
-        -- (cong (_∘g f) {!sym ⊗-unit-rr⁻!})
-      -- ⊗-unit-r ∘g ⊗-intro f id
-      --   ≡⟨ {!cong-∘g⊗-unit-r!} ⟩
-      -- f ∘g ⊗-unit-r
-      -- ∎
 
     ⊗-unit-rl⁻ : ⊗-unit-r ∘g ⊗-unit-l⁻ ≡ id
     ⊗-unit-rl⁻ = funExt λ w → funExt λ p →
       isSetString w [] ((⊗-unit-r ∘g ⊗-unit-l⁻) w p) (id {g = ε} w p)
+
+    --technically this follows from more basic monoidal category axioms but it's not simple
+    ⊗-unit-lr⁻ : ⊗-unit-l ∘g ⊗-unit-r⁻ ≡ id
+    ⊗-unit-lr⁻ = funExt λ w → funExt λ p →
+      isSetString w [] ((⊗-unit-l ∘g ⊗-unit-r⁻ ) w p) ((id {g = ε} w p))
 
   ⊗-unit-r' :
     g ⊗ ε ⊢ g
@@ -301,6 +297,14 @@ opaque
   ⊗-assoc⁻⊗-intro = refl
 
   opaque
+    unfolding ⊗-unit-r⁻
+    ⊗-assoc⁻⊗-unit-r⁻ :
+      ⊗-assoc⁻ {g = g}{h = h} ∘g ⊗-unit-r⁻ ≡ ⊗-intro id ⊗-unit-r⁻
+    ⊗-assoc⁻⊗-unit-r⁻ = funExt λ w → funExt λ p →
+      ⊗≡ _ _ (≡-× refl (++-unit-r _))
+        (ΣPathP (refl , ⊗PathP refl refl))
+
+  opaque
     unfolding ε ⊗-unit-l⁻
     ⊗-unit-l⁻⊗-intro :
       ∀ {f : g ⊢ h}
@@ -308,14 +312,54 @@ opaque
       ≡ (⊗-intro id f) ∘g ⊗-unit-l⁻
     ⊗-unit-l⁻⊗-intro = refl
 
+    ⊗-unit-l⊗-intro :
+      ∀ (f : g ⊢ h)
+      → f ∘g ⊗-unit-l
+        ≡ ⊗-unit-l ∘g (⊗-intro id f)
+    ⊗-unit-l⊗-intro f =
+      cong-∘g⊗-unit-l⁻ _ _
+        λ i → ⊗-unit-l⁻l (~ i) ∘g f ∘g ⊗-unit-l⁻l i
+
     ⊗-unit-r⁻⊗-intro :
       ∀ {f : g ⊢ h}
       → ⊗-unit-r⁻ ∘g f
       ≡ (⊗-intro f id) ∘g ⊗-unit-r⁻
     ⊗-unit-r⁻⊗-intro = refl
 
+    -- this is the fact that the inverse of a natural transformation is natural
+    ⊗-unit-r⊗-intro :
+      (f : g ⊢ h) →
+      ⊗-unit-r ∘g ⊗-intro f id ≡ f ∘g ⊗-unit-r
+    ⊗-unit-r⊗-intro f =
+      cong-∘g⊗-unit-r⁻ _ _
+        (λ i → ⊗-unit-r⁻r i ∘g f ∘g ⊗-unit-r⁻r (~ i))
+
     id,⊗id≡id : ⊗-intro id id ≡ id {g = g ⊗ h}
     id,⊗id≡id = refl
 
 _,⊗_ = ⊗-intro
 infixr 20 _,⊗_
+
+⊗-assoc⁻3 :
+  (g ⊗ g' ⊗ g'') ⊗ g''' ⊢ g ⊗ g' ⊗ g'' ⊗ g'''
+⊗-assoc⁻3 = id ,⊗ ⊗-assoc⁻ ∘g ⊗-assoc⁻  
+
+⊗-assoc⁻3⊗-unit-r⁻ :
+  ⊗-assoc⁻3 {g = g}{g' = g'}{g'' = g''} ∘g ⊗-unit-r⁻
+  ≡ id ,⊗ id ,⊗ ⊗-unit-r⁻
+⊗-assoc⁻3⊗-unit-r⁻ =
+  cong (id ,⊗ ⊗-assoc⁻ ∘g_) ⊗-assoc⁻⊗-unit-r⁻
+  ∙ ⊗-intro⊗-intro
+  ∙ cong (id ,⊗_) ⊗-assoc⁻⊗-unit-r⁻
+
+⊗-assoc⁻4 :
+  (g ⊗ g' ⊗ g'' ⊗ g''') ⊗ g'''' ⊢ g ⊗ g' ⊗ g'' ⊗ g''' ⊗ g''''
+⊗-assoc⁻4 = id ,⊗ ⊗-assoc⁻3 ∘g ⊗-assoc⁻
+
+⊗-assoc⁻4⊗-unit-r⁻ :
+  ⊗-assoc⁻4 {g = g}{g' = g'}{g'' = g''}{g''' = g'''} ∘g ⊗-unit-r⁻
+  ≡ id ,⊗ id ,⊗ id ,⊗ ⊗-unit-r⁻
+⊗-assoc⁻4⊗-unit-r⁻ =
+  cong (id ,⊗ ⊗-assoc⁻3 ∘g_) ⊗-assoc⁻⊗-unit-r⁻
+  ∙ ⊗-intro⊗-intro
+  ∙ cong (id ,⊗_) ⊗-assoc⁻3⊗-unit-r⁻

--- a/code/cubical/Grammar/LinearProduct.agda
+++ b/code/cubical/Grammar/LinearProduct.agda
@@ -302,7 +302,8 @@ opaque
     ∀ {f : g ⊢ h}{f' : g' ⊢ h'}{f'' : g'' ⊢ h''}
     → ⊗-assoc ∘g ⊗-intro f (⊗-intro f' f'')
       ≡ ⊗-intro (⊗-intro f f') f'' ∘g ⊗-assoc
-  ⊗-assoc⊗-intro = {!!}
+  ⊗-assoc⊗-intro = funExt λ w → funExt λ p →
+    ⊗≡ _ _ (≡-× refl refl) (ΣPathP (refl , refl))
 
   opaque
     unfolding ⊗-unit-r⁻
@@ -313,9 +314,11 @@ opaque
         (ΣPathP (refl , ⊗PathP refl refl))
 
   opaque
+    unfolding ⊗-unit-l⁻
     ⊗-assoc⊗-unit-l⁻ :
-      ⊗-assoc {g = g}{k = k} ∘g ⊗-intro id ⊗-unit-l⁻ ≡ ⊗-intro ⊗-unit-r⁻ id
-    ⊗-assoc⊗-unit-l⁻ = {!!}
+     ⊗-assoc {g = g}{k = k} ∘g ⊗-intro id ⊗-unit-l⁻ ≡ ⊗-intro ⊗-unit-r⁻ id
+    ⊗-assoc⊗-unit-l⁻ = funExt λ w → funExt λ p →
+      ⊗≡ _ _ (≡-× (++-unit-r _) refl) (ΣPathP (⊗PathP refl refl , refl))
 
   opaque
     unfolding ε ⊗-unit-l⁻
@@ -377,11 +380,18 @@ infixr 20 _,⊗_
   g ⊗ g' ⊗ g'' ⊗ g''' ⊗ g'''' ⊢ (g ⊗ g' ⊗ g'' ⊗ g''') ⊗ g''''
 ⊗-assoc4 = ⊗-assoc ∘g id ,⊗ ⊗-assoc3
 
-⊗-assoc⁻4⊗-assoc :
-  ⊗-assoc⁻4 {g = g}{g' = g'}{g'' = g''}{g''' = g'''}{g'''' = g''''} ,⊗ id {g = g'''''}
-  ∘g ⊗-assoc
-  ≡ ⊗-assoc4 ∘g id ,⊗ id ,⊗ id ,⊗ ⊗-assoc ∘g ⊗-assoc⁻4
-⊗-assoc⁻4⊗-assoc = {!!}
+opaque
+  unfolding ⊗-intro ⊗-assoc ⊗-assoc⁻
+  ⊗-assoc⁻4⊗-assoc :
+    ⊗-assoc⁻4 {g = g}{g' = g'}{g'' = g''}{g''' = g'''}{g'''' = g''''} ,⊗ id {g = g'''''}
+    ∘g ⊗-assoc
+    ≡ ⊗-assoc4 ∘g id ,⊗ id ,⊗ id ,⊗ ⊗-assoc ∘g ⊗-assoc⁻4
+  ⊗-assoc⁻4⊗-assoc = funExt λ w → funExt λ p →
+    ⊗PathP (≡-×
+      ((λ i → p .snd .fst .fst .snd i ++ p .snd .snd .fst .fst .fst)
+       ∙ ++-assoc (p .snd .fst .fst .fst .fst) _ _
+       ∙ {!p .snd  .fst .fst .snd!})
+      refl) (ΣPathP ({!!} , {!!}))
 
 ⊗-assoc⁻4⊗-unit-r⁻ :
   ⊗-assoc⁻4 {g = g}{g' = g'}{g'' = g''}{g''' = g'''} ∘g ⊗-unit-r⁻
@@ -398,14 +408,16 @@ infixr 20 _,⊗_
 ⊗-assoc⁻3⊗-intro =
   {!!}
 
-⊗-assoc⁻4⊗-intro :
-  ∀ {f f' f'' f''' f''''} →
-  (⊗-assoc⁻4 {g = g}{g' = g'}{g'' = g''}{g''' = g'''}{g'''' = g''''} ∘g (f ,⊗ f' ,⊗ f'' ,⊗ f''') ,⊗ f'''')
-  ≡ (f ,⊗ f' ,⊗ f'' ,⊗ f''' ,⊗ f'''' ∘g (⊗-assoc⁻4 {g = h}{g' = h'}{g'' = h''}{g''' = h'''}{g'''' = h''''}))
-⊗-assoc⁻4⊗-intro =
-  cong (id ,⊗ ⊗-assoc⁻3 ∘g_) ⊗-assoc⁻⊗-intro
-  ∙ cong (_∘g ⊗-assoc⁻) (⊗-intro⊗-intro ∙ cong (⊗-intro _) ⊗-assoc⁻3⊗-intro)
-  ∙ {!sym ⊗-intro⊗-intro!}
+opaque
+  unfolding ⊗-intro
+  ⊗-assoc⁻4⊗-intro :
+    ∀ {f f' f'' f''' f''''} →
+    (⊗-assoc⁻4 {g = g}{g' = g'}{g'' = g''}{g''' = g'''}{g'''' = g''''} ∘g (f ,⊗ f' ,⊗ f'' ,⊗ f''') ,⊗ f'''')
+    ≡ (f ,⊗ f' ,⊗ f'' ,⊗ f''' ,⊗ f'''' ∘g (⊗-assoc⁻4 {g = h}{g' = h'}{g'' = h''}{g''' = h'''}{g'''' = h''''}))
+  ⊗-assoc⁻4⊗-intro {f = f} {f' = f'} {f'' = f''} {f''' = f'''} {f'''' = f''''} =
+    cong (id ,⊗ ⊗-assoc⁻3 ∘g_) (⊗-assoc⁻⊗-intro {f' = f' ,⊗ f'' ,⊗ f'''})
+    ∙ cong (_∘g ⊗-assoc⁻) {!!} -- (cong (⊗-intro _) ⊗-assoc⁻3⊗-intro {f = ?}{f' = ?}{f'' = ?}{f''' = ?})
+    ∙ {!!}
 
 ⊗-assoc4⊗-intro :
   ⊗-assoc4 ∘g f ,⊗ f' ,⊗ f'' ,⊗ f''' ,⊗ f''''

--- a/code/cubical/Grammar/LinearProduct.agda
+++ b/code/cubical/Grammar/LinearProduct.agda
@@ -16,7 +16,7 @@ private
   variable
     ℓg ℓh ℓk ℓl ℓ ℓ' : Level
     g g' g'' g''' g'''' g''''' : Grammar ℓg
-    h h' h'' : Grammar ℓh
+    h h' h'' h''' h'''' h''''' : Grammar ℓh
     k : Grammar ℓk
     l : Grammar ℓl
 
@@ -316,6 +316,10 @@ opaque
       ≡ ⊗-unit-l
     ⊗-unit-l⊗-assoc = {!!}
 
+    ⊗-assoc⊗-unit-l⁻ :
+      ⊗-assoc {g = g}{k = k} ∘g ⊗-intro id ⊗-unit-l⁻ ≡ ⊗-intro ⊗-unit-r⁻ id
+    ⊗-assoc⊗-unit-l⁻ = {!!}
+
   opaque
     unfolding ε ⊗-unit-l⁻
     ⊗-unit-l⁻⊗-intro :
@@ -375,3 +379,19 @@ infixr 20 _,⊗_
   cong (id ,⊗ ⊗-assoc⁻3 ∘g_) ⊗-assoc⁻⊗-unit-r⁻
   ∙ ⊗-intro⊗-intro
   ∙ cong (id ,⊗_) ⊗-assoc⁻3⊗-unit-r⁻
+
+⊗-assoc⁻3⊗-intro :
+  ∀ {f f' f'' f'''} →
+  (⊗-assoc⁻3 {g = g}{g' = g'}{g'' = g''}{g''' = g'''} ∘g (f ,⊗ f' ,⊗ f'') ,⊗ f''')
+  ≡ (f ,⊗ f' ,⊗ f'' ,⊗ f''' ∘g (⊗-assoc⁻3 {g = h}{g' = h'}{g'' = h''}{g''' = h'''}))
+⊗-assoc⁻3⊗-intro =
+  {!!}
+
+⊗-assoc⁻4⊗-intro :
+  ∀ {f f' f'' f''' f''''} →
+  (⊗-assoc⁻4 {g = g}{g' = g'}{g'' = g''}{g''' = g'''}{g'''' = g''''} ∘g (f ,⊗ f' ,⊗ f'' ,⊗ f''') ,⊗ f'''')
+  ≡ (f ,⊗ f' ,⊗ f'' ,⊗ f''' ,⊗ f'''' ∘g (⊗-assoc⁻4 {g = h}{g' = h'}{g'' = h''}{g''' = h'''}{g'''' = h''''}))
+⊗-assoc⁻4⊗-intro =
+  cong (id ,⊗ ⊗-assoc⁻3 ∘g_) ⊗-assoc⁻⊗-intro
+  ∙ cong (_∘g ⊗-assoc⁻) (⊗-intro⊗-intro ∙ cong (⊗-intro _) ⊗-assoc⁻3⊗-intro)
+  ∙ {!sym ⊗-intro⊗-intro!}

--- a/code/cubical/Grammar/Properties.agda
+++ b/code/cubical/Grammar/Properties.agda
@@ -31,7 +31,7 @@ open import Term.Base Alphabet
 
 private
   variable
-    ℓg ℓh ℓk ℓl ℓS : Level
+    ℓ ℓ' ℓg ℓh ℓk ℓl ℓS : Level
     g : Grammar ℓg
     h : Grammar ℓh
     k : Grammar ℓk

--- a/code/cubical/Term/Base.agda
+++ b/code/cubical/Term/Base.agda
@@ -65,3 +65,12 @@ Mono∘g : (e : g ⊢ h) (e' : h ⊢ k) →
   isMono e' → isMono e → isMono (e' ∘g e)
 Mono∘g e e' mon-e mon-e' f f' e'ef≡e'ef' =
   mon-e' f f' (mon-e (e ∘g f) (e ∘g f') e'ef≡e'ef')
+
+transportG :
+  g ≡ h
+  → g ⊢ h
+transportG {g = g}{h = h} p = subst (λ h → g ⊢ h) p id
+
+transportGRefl :
+  transportG {g = g} refl ≡ id
+transportGRefl {g = g} = substRefl {B = λ h → g ⊢ h} _


### PR DESCRIPTION
This involved a new linear type constructor for equalizers. Fortunately with that done the inductive proof was more intuitive to finish. There's still some nasty monoidal category lemmas to prove. Making this a draft so @stschaef can fill some of those in if he has time. Feel free to prove these externally if they're easier. They would all be automatic in a true linear lambda calculus anyway.